### PR TITLE
commandOptionとModalのテストと修正

### DIFF
--- a/src/flow-typed/global.js
+++ b/src/flow-typed/global.js
@@ -1,2 +1,23 @@
 declare type RoleId = 'villager' | 'seer' | 'medium' | 'hunter' | 'mason' | 'madman' | 'werewolf' | 'werehumster'
 declare type BoardState = '?' | 'Δ' | 'O' | 'X' | 'fill' | 'fix'
+declare type Phase = 'day conversation' | 'day vote' | 'night' | 'results' | 'post mortem'
+declare type Language = 'ja' | 'en'
+declare type Result = 'win' | 'lose'
+declare type AgentStatus = 'alive' | 'dead' | 'death by execution' | 'death by werewolf attack' | 'death by fear' | 'unnatural death'
+declare type Agent = {
+  '@id': string,
+  'agentIsMine': boolean,
+  'name': { [Language]: string },
+  'image': string,
+  'id': number,
+  'role'?: {
+    '@id': string,
+    'roleName': { [Language]: string },
+    'roleImage': string
+  },
+  'status': AgentStatus,
+  'statusUpdatePhase': Phase,
+  'statusUpdateDate': number,
+  'isAChoice': boolean,
+  'result': Result
+}

--- a/src/scripts/village/actions/index.js
+++ b/src/scripts/village/actions/index.js
@@ -71,12 +71,12 @@ export const selectOption = agentId => ({
 })
 
 export const selectNo = () => ({
-  type: types.SELECT_YES
+  type: types.SELECT_NO
 })
 
-export const selectYes = agent => ({
-  agent,
-  type: types.SELECT_NO
+export const selectYes = agentId => ({
+  agentId,
+  type: types.SELECT_YES
 })
 
 export const handleClickHideButton = isHide => ({

--- a/src/scripts/village/actions/index.js
+++ b/src/scripts/village/actions/index.js
@@ -65,8 +65,8 @@ export const handleBoardClick = (nextState, playerId, roleId) => ({
   type: types.CHANGE_PREDICTION_BOARD
 })
 
-export const selectOption = agent => ({
-  agent,
+export const selectOption = agentId => ({
+  agentId,
   type: types.SELECT_OPTION
 })
 

--- a/src/scripts/village/components/CommandOption.js
+++ b/src/scripts/village/components/CommandOption.js
@@ -1,7 +1,16 @@
+// @flow
 import React from 'react'
 
-export default function CommandOption(props) {
-  const handleSelectOption = event => {
+type Props = {
+  agent: Agent,
+  handleSelectOption: (Object) => void,
+  id: number,
+  image: string,
+  name: string
+}
+
+export default function CommandOption(props: Props) {
+  const handleSelectOption = () => {
     props.handleSelectOption(props.agent)
   }
 

--- a/src/scripts/village/components/CommandOption.js
+++ b/src/scripts/village/components/CommandOption.js
@@ -2,8 +2,7 @@
 import React from 'react'
 
 type Props = {
-  agent: Agent,
-  handleSelectOption: (Object) => void,
+  handleSelectOption: number => void,
   id: number,
   image: string,
   name: string
@@ -11,7 +10,7 @@ type Props = {
 
 export default function CommandOption(props: Props) {
   const handleSelectOption = () => {
-    props.handleSelectOption(props.agent)
+    props.handleSelectOption(props.id)
   }
 
   return (

--- a/src/scripts/village/components/CommandOption.test.js
+++ b/src/scripts/village/components/CommandOption.test.js
@@ -1,0 +1,45 @@
+import CommandOption from './CommandOption'
+import React from 'react'
+import {shallow} from 'enzyme'
+
+test('<CommandOption id={1} image="image" name="name" />', () => {
+  const wrapper = shallow(<CommandOption id={1} image="image" name="name" />)
+
+  expect(wrapper.is('.command--option[data-player=1]')).toBe(true)
+  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.text()).toBe('name')
+})
+test('<CommandOption id={undefined} image="image" name="name" />', () => {
+  const wrapper = shallow(<CommandOption image="image" name="name" />)
+
+  expect(wrapper.is('.command--option[data-player]')).toBe(false)
+  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.text()).toBe('name')
+})
+test('<CommandOption id={1} image={undefined} name="name" />', () => {
+  const wrapper = shallow(<CommandOption id={1} name="name" />)
+
+  expect(wrapper.is('.command--option[data-player=1]')).toBe(true)
+  expect(wrapper.containsMatchingElement(<img />)).toBe(true)
+  expect(wrapper.text()).toBe('name')
+})
+test('<CommandOption id={1} image="image" name={undefined} />', () => {
+  const wrapper = shallow(<CommandOption id={1} image="image" />)
+
+  expect(wrapper.is('.command--option[data-player=1]')).toBe(true)
+  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.text()).toBe('')
+})
+test('<CommandOption id={1} image="image" name="name" /> handleSelectOption', () => {
+  const mockFn = jest.fn().mockName('handleSelectOption')
+  const wrapper = shallow(<CommandOption handleSelectOption={mockFn} id={1} image="image" name="name" />)
+
+  expect(wrapper.is('.command--option[data-player=1]')).toBe(true)
+  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.text()).toBe('name')
+  wrapper.simulate('click')
+  expect(mockFn).toHaveBeenCalledWith(1)
+  expect(wrapper.is('.command--option[data-player=1]')).toBe(true)
+  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.text()).toBe('name')
+})

--- a/src/scripts/village/components/Description.js
+++ b/src/scripts/village/components/Description.js
@@ -1,0 +1,21 @@
+// @flow
+import React from 'react'
+import Timer from '../containers/TimerContainer'
+
+type Props = {
+  class: string,
+  text: string
+}
+
+export default function Description(props: Props) {
+  return (
+    <div className={props.class}>
+      <span>
+        {props.text}
+      </span>
+      {'（'}
+      <Timer />
+      {'）'}
+    </div>
+  )
+}

--- a/src/scripts/village/components/Description.test.js
+++ b/src/scripts/village/components/Description.test.js
@@ -1,0 +1,16 @@
+import Description from './Description'
+import React from 'react'
+import {shallow} from 'enzyme'
+
+test('<Description class="class" text="text" />', () => {
+  const wrapper = shallow(<Description class="class" text="text" />)
+
+  expect(wrapper.is('.class')).toBe(true)
+  expect(wrapper.text()).toBe('text（<Connect(Timer) />）')
+})
+test('<Description class="class" text={undefined} />', () => {
+  const wrapper = shallow(<Description class="class" />)
+
+  expect(wrapper.is('.class')).toBe(true)
+  expect(wrapper.text()).toBe('（<Connect(Timer) />）')
+})

--- a/src/scripts/village/components/Modal.js
+++ b/src/scripts/village/components/Modal.js
@@ -4,10 +4,13 @@ import React from 'react'
 import RoleIcon from './RoleIcon'
 
 type Props = {
+  handleClickNo: void => void,
+  handleClickYes: number => void,
   id: number,
   image: string,
   name: string,
-  text: string
+  text: string,
+  visible: boolean
 }
 
 export default function Modal(props: Props) {
@@ -15,8 +18,8 @@ export default function Modal(props: Props) {
     return ''
   }
 
-  const handleClick = event => {
-    if (event.target.value === 'no') {
+  const handleClick = value => () => {
+    if (value === 'no') {
       props.handleClickNo()
     } else {
       props.handleClickYes(props.id)
@@ -28,10 +31,10 @@ export default function Modal(props: Props) {
       <RoleIcon agent={props.name} class="modal--icon" image={props.image} />
       <Description class="modal--description" text={props.text} />
       <div className="modal--button--container">
-        <button className="modal--button" onClick={handleClick} value="yes">
+        <button className="modal--button" onClick={handleClick('yes')} value="yes">
           {'はい'}
         </button>
-        <button className="modal--button" onClick={handleClick} value="no">
+        <button className="modal--button" onClick={handleClick('no')} value="no">
           {'いいえ'}
         </button>
       </div>

--- a/src/scripts/village/components/Modal.js
+++ b/src/scripts/village/components/Modal.js
@@ -1,8 +1,17 @@
+// @flow
+import Description from './Description'
 import React from 'react'
-import Timer from './Timer'
+import RoleIcon from './RoleIcon'
 
-export default function Modal(props) {
-  if (!props.isVisible) {
+type Props = {
+  id: number,
+  image: string,
+  name: string,
+  text: string
+}
+
+export default function Modal(props: Props) {
+  if (!props.visible) {
     return ''
   }
 
@@ -10,31 +19,19 @@ export default function Modal(props) {
     if (event.target.value === 'no') {
       props.handleClickNo()
     } else {
-      props.handleClickYes(props.agent)
+      props.handleClickYes(props.id)
     }
   }
 
   return (
-    <div className="modal" id="modal">
-      <div className="modal--icon">
-        <img id="modal-icon-image" src={props.image} />
-        <span id="modal-icon-name">
-          {props.name}
-        </span>
-      </div>
-      <div className="modal--description">
-        <span id="modal-text">
-          {props.text}
-        </span>
-        {'（'}
-        <Timer id="modal-time" />
-        {'）'}
-      </div>
+    <div className="modal">
+      <RoleIcon agent={props.name} class="modal--icon" image={props.image} />
+      <Description class="modal--description" text={props.text} />
       <div className="modal--button--container">
-        <button className="modal--button" id="yes" onClick={handleClick} value="yes">
+        <button className="modal--button" onClick={handleClick} value="yes">
           {'はい'}
         </button>
-        <button className="modal--button" id="no" onClick={handleClick} value="no">
+        <button className="modal--button" onClick={handleClick} value="no">
           {'いいえ'}
         </button>
       </div>

--- a/src/scripts/village/components/Modal.test.js
+++ b/src/scripts/village/components/Modal.test.js
@@ -1,0 +1,88 @@
+import Modal from './Modal'
+import React from 'react'
+import {shallow} from 'enzyme'
+
+test('<Modal id={1} image="image" name="name" text="text" visible />', () => {
+  const wrapper = shallow(
+    <Modal
+      id={1}
+      image="image"
+      name="name"
+      text="text"
+      visible
+    />
+  )
+
+  expect(wrapper.find('RoleIcon').exists()).toBe(true)
+  expect(wrapper.find('Description').exists()).toBe(true)
+  expect(wrapper.find('.modal--button')).toHaveLength(2)
+  expect(wrapper.find('.modal--button').filter('[value="yes"]')).toHaveLength(1)
+  expect(wrapper.find('.modal--button').filter('[value="yes"]').text()).toBe('はい')
+  expect(wrapper.find('.modal--button').filter('[value="no"]')).toHaveLength(1)
+  expect(wrapper.find('.modal--button').filter('[value="no"]').text()).toBe('いいえ')
+})
+test('<Modal visible={false} />', () => {
+  const wrapper = shallow(<Modal visible={false} />)
+
+  expect(wrapper.find('.modal').exists()).toBe(false)
+})
+test('<Modal id={1} image="image" name="name" text="text" visible /> handleClickNo', () => {
+  const handleClickNoMockFn = jest.fn().mockName('handleClickNo')
+  const handleClickYesMockFn = jest.fn().mockName('handleClickYes')
+  const wrapper = shallow(
+    <Modal
+      handleClickNo={handleClickNoMockFn}
+      handleClickYes={handleClickYesMockFn}
+      id={1}
+      image="image"
+      name="name"
+      text="text"
+      visible
+    />
+  )
+
+  expect(wrapper.find('.modal--button')).toHaveLength(2)
+  expect(wrapper.find('.modal--button').filter('[value="yes"]')).toHaveLength(1)
+  expect(wrapper.find('.modal--button').filter('[value="yes"]').text()).toBe('はい')
+  expect(wrapper.find('.modal--button').filter('[value="no"]')).toHaveLength(1)
+  expect(wrapper.find('.modal--button').filter('[value="no"]').text()).toBe('いいえ')
+  wrapper.find('.modal--button[value="no"]').simulate('click')
+  expect(handleClickNoMockFn).toHaveBeenCalledTimes(1)
+  expect(handleClickYesMockFn).toHaveBeenCalledTimes(0)
+  expect(handleClickNoMockFn).toHaveBeenCalledWith()
+  expect(wrapper.find('.modal--button')).toHaveLength(2)
+  expect(wrapper.find('.modal--button').filter('[value="yes"]')).toHaveLength(1)
+  expect(wrapper.find('.modal--button').filter('[value="yes"]').text()).toBe('はい')
+  expect(wrapper.find('.modal--button').filter('[value="no"]')).toHaveLength(1)
+  expect(wrapper.find('.modal--button').filter('[value="no"]').text()).toBe('いいえ')
+})
+test('<Modal id={1} image="image" name="name" text="text" visible /> handleClickYes', () => {
+  const handleClickNoMockFn = jest.fn().mockName('handleClickNo')
+  const handleClickYesMockFn = jest.fn().mockName('handleClickYes')
+  const wrapper = shallow(
+    <Modal
+      handleClickNo={handleClickNoMockFn}
+      handleClickYes={handleClickYesMockFn}
+      id={1}
+      image="image"
+      name="name"
+      text="text"
+      visible
+    />
+  )
+
+  expect(wrapper.find('.modal--button')).toHaveLength(2)
+  expect(wrapper.find('.modal--button').filter('[value="yes"]')).toHaveLength(1)
+  expect(wrapper.find('.modal--button').filter('[value="yes"]').text()).toBe('はい')
+  expect(wrapper.find('.modal--button').filter('[value="no"]')).toHaveLength(1)
+  expect(wrapper.find('.modal--button').filter('[value="no"]').text()).toBe('いいえ')
+  wrapper.find('.modal--button[value="yes"]').simulate('click')
+  expect(handleClickNoMockFn).toHaveBeenCalledTimes(0)
+  expect(handleClickYesMockFn).toHaveBeenCalledTimes(1)
+  expect(handleClickYesMockFn).toHaveBeenCalledWith(1)
+  expect(wrapper.find('.modal--button')).toHaveLength(2)
+  expect(wrapper.find('.modal--button').filter('[value="yes"]')).toHaveLength(1)
+  expect(wrapper.find('.modal--button').filter('[value="yes"]').text()).toBe('はい')
+  expect(wrapper.find('.modal--button').filter('[value="no"]')).toHaveLength(1)
+  expect(wrapper.find('.modal--button').filter('[value="no"]').text()).toBe('いいえ')
+})

--- a/src/scripts/village/containers/CommandContainer.js
+++ b/src/scripts/village/containers/CommandContainer.js
@@ -34,7 +34,7 @@ const mapDispatchToProps = dispatch => ({
     kind,
     text
   })),
-  handleSelectOption: agent => dispatch(selectOption(agent)),
+  handleSelectOption: agentId => dispatch(selectOption(agentId)),
   setIsSendable: kind => isSendable => dispatch(setIsSendable({
     isSendable,
     kind

--- a/src/scripts/village/containers/ModalContainer.js
+++ b/src/scripts/village/containers/ModalContainer.js
@@ -21,10 +21,17 @@ const getText = (phase, myRole) => {
   }
 }
 
-const mapStateToProps = state => ({
-  ... state.modal,
-  text: getText(state.base.phase, state.mine.myRole)
-})
+const mapStateToProps = state => {
+  const agent = state.agent.filter(a => a.id === state.modal.agentId)
+
+  return {
+    id: agent.id,
+    image: agent.image,
+    name: agent.name.ja,
+    text: getText(state.base.phase, state.mine.myRole),
+    visible: state.modal.visible
+  }
+}
 const mapDispatchToProps = dispatch => ({
   handleClickNo: () => dispatch(selectNo()),
   handleClickYes: selectedAgent => dispatch(selectYes(selectedAgent))

--- a/src/scripts/village/middlewares/client2server.js
+++ b/src/scripts/village/middlewares/client2server.js
@@ -113,6 +113,7 @@ const client2server = store => next => action => {
     }
     case types.SELECT_YES: {
       const state = store.getState()
+      const agent = state.agents.filter(a => a.id === action.agentId)[0]
       const payload = Object.assign(
         {},
         state.base,
@@ -130,10 +131,10 @@ const client2server = store => next => action => {
         },
         {
           'votedAgent': {
-            '@id': action.agent['@id'],
-            'votedAgentId': action.agent.id,
-            'votedAgentImage': action.agent.image,
-            'votedAgentName': action.agemt.name
+            '@id': agent['@id'],
+            'votedAgentId': agent.id,
+            'votedAgentImage': agent.image,
+            'votedAgentName': agent.name
           }
         }
       )

--- a/src/scripts/village/reducers/modal.js
+++ b/src/scripts/village/reducers/modal.js
@@ -1,19 +1,19 @@
 import * as ActionTypes from '../constants/ActionTypes'
 
 const initialState = {
-  isVisible: false
+  visible: false
 }
 const modal = (state = initialState, action) => {
   switch (action.type) {
     case ActionTypes.SELECT_OPTION:
       return {
-        agent: action.agent,
-        isVisible: true
+        id: action.agentId,
+        visible: true
       }
     case ActionTypes.SELECT_NO:
     case ActionTypes.SELECT_YES:
       return {
-        isVisible: false
+        visible: false
       }
     default:
       return state


### PR DESCRIPTION
- Modalの実装が間違っているので直す
- commandOptionのhandleSelectOptionとModalのhandleClickは`agent`を含むActionをDispatchしていたが，テストの書きやすさの観点から`agent`から`agentId`に変更する．
- 上記の変更からmiddlewareのclient2serverの変更をする
- ModalからRoleIconとDescriptionを切り出した