### PR TITLE
Timerの修正

### DIFF
--- a/src/scripts/village/components/CommandSelection.js
+++ b/src/scripts/village/components/CommandSelection.js
@@ -1,6 +1,6 @@
 import CommandOption from './CommandOption'
 import React from 'react'
-import Timer from './Timer'
+import Timer from '../containers/TimerContainer'
 
 export default function CommandSelection(props) {
   return (
@@ -10,7 +10,7 @@ export default function CommandSelection(props) {
           {props.text}
         </span>
         {'（'}
-        <Timer id="select-time" />
+        <Timer />
         {'）'}
       </div>
       <div className="command--option-container" id="command--option-container">

--- a/src/scripts/village/components/Day.js
+++ b/src/scripts/village/components/Day.js
@@ -15,7 +15,7 @@ export default function Day(props: Props) {
         <span>
           {`${props.date}日目 ${props.phase}`}
         </span>
-        <Timer id="day-time" phaseTimeLimit={props.phaseTimeLimit} />
+        <Timer />
       </div>
     </div>
   )

--- a/src/scripts/village/components/FormattedTime.js
+++ b/src/scripts/village/components/FormattedTime.js
@@ -9,13 +9,12 @@ const formatTime = time => {
 }
 
 type Props = {
-  id: string,
   time: number
 }
 
 export default function FormattedTime(props: Props) {
   return (
-    <span id={props.id}>
+    <span>
       {props.time < 0 ? '終了' : formatTime(props.time)}
     </span>
   )

--- a/src/scripts/village/components/FormattedTime.test.js
+++ b/src/scripts/village/components/FormattedTime.test.js
@@ -3,56 +3,47 @@ import React from 'react'
 import {shallow} from 'enzyme'
 
 test('time = 5999 => 残り99\'59', () => {
-  const wrapper = shallow(<FormattedTime id="timer" time={5999} />)
+  const wrapper = shallow(<FormattedTime time={5999} />)
 
-  expect(wrapper.find('#timer')).toHaveLength(1)
   expect(wrapper.text()).toBe('残り99\'59')
 })
 test('time = 90 => 残り01\'30', () => {
-  const wrapper = shallow(<FormattedTime id="timer" time={90} />)
+  const wrapper = shallow(<FormattedTime time={90} />)
 
-  expect(wrapper.find('#timer')).toHaveLength(1)
   expect(wrapper.text()).toBe('残り01\'30')
 })
 test('time = 30 => 残り00\'30', () => {
-  const wrapper = shallow(<FormattedTime id="timer" time={30} />)
+  const wrapper = shallow(<FormattedTime time={30} />)
 
-  expect(wrapper.find('#timer')).toHaveLength(1)
   expect(wrapper.text()).toBe('残り00\'30')
 })
 test('time = 5 => 残り00\'05', () => {
-  const wrapper = shallow(<FormattedTime id="timer" time={5} />)
+  const wrapper = shallow(<FormattedTime time={5} />)
 
-  expect(wrapper.find('#timer')).toHaveLength(1)
   expect(wrapper.text()).toBe('残り00\'05')
 })
 test('time = 0 => 残り00\'00', () => {
-  const wrapper = shallow(<FormattedTime id="timer" time={0} />)
+  const wrapper = shallow(<FormattedTime time={0} />)
 
-  expect(wrapper.find('#timer')).toHaveLength(1)
   expect(wrapper.text()).toBe('残り00\'00')
 })
 test('time = -1 => 終了', () => {
-  const wrapper = shallow(<FormattedTime id="timer" time={-1} />)
+  const wrapper = shallow(<FormattedTime time={-1} />)
 
-  expect(wrapper.find('#timer')).toHaveLength(1)
   expect(wrapper.text()).toBe('終了')
 })
 test('time = 6000 => 残り100\'00', () => {
-  const wrapper = shallow(<FormattedTime id="timer" time={6000} />)
+  const wrapper = shallow(<FormattedTime time={6000} />)
 
-  expect(wrapper.find('#timer')).toHaveLength(1)
   expect(wrapper.text()).toBe('残り100\'00')
 })
 test('time = \'5\' => 残り00\'05', () => {
-  const wrapper = shallow(<FormattedTime id="timer" time="5" />)
+  const wrapper = shallow(<FormattedTime time="5" />)
 
-  expect(wrapper.find('#timer')).toHaveLength(1)
   expect(wrapper.text()).toBe('残り00\'05')
 })
 test('time = undefined => 残りNaN\'NaN', () => {
-  const wrapper = shallow(<FormattedTime id="timer" />)
+  const wrapper = shallow(<FormattedTime />)
 
-  expect(wrapper.find('#timer')).toHaveLength(1)
   expect(wrapper.text()).toBe('残りNaN\'NaN')
 })

--- a/src/scripts/village/components/Timer.js
+++ b/src/scripts/village/components/Timer.js
@@ -3,7 +3,6 @@ import FormatedTime from './FormattedTime'
 import React from 'react'
 
 type Props = {
-  id: string,
   limit: number
 }
 
@@ -38,7 +37,7 @@ export default class Timer extends React.Component<Props, State> {
 
   render() {
     return (
-      <FormatedTime id={this.props.id} time={this.state.time} />
+      <FormatedTime time={this.state.time} />
     )
   }
 }

--- a/src/scripts/village/containers/TimerContainer.js
+++ b/src/scripts/village/containers/TimerContainer.js
@@ -2,9 +2,7 @@ import Timer from '../components/Timer'
 import {connect} from 'react-redux'
 
 const mapStateToProps = state => ({
-  limit: state.timer.phaseTimeLimit === -1 ? -1 : state.timer.phaseTimeLimit,
-  phase: state.timer.phase,
-  start: new Date(state.timer.phaseStartTime).getTime()
+  limit: state.timer.phaseTimeLimit === -1 ? -1 : state.timer.phaseTimeLimit
 })
 const TimerContainer = connect(
   mapStateToProps,

--- a/src/scripts/village/reducers/timer.js
+++ b/src/scripts/village/reducers/timer.js
@@ -3,7 +3,6 @@ import * as Contexts from '../constants/Contexts'
 
 const initialState = {
   phase: '',
-  phaseStartTime: '',
   phaseTimeLimit: 0
 }
 const timer = (state = initialState, action) => {
@@ -15,7 +14,6 @@ const timer = (state = initialState, action) => {
       ) {
         return {
           phase: action.payload.phase,
-          phaseStartTime: action.payload.phaseStartTime,
           phaseTimeLimit: action.payload.phaseTimeLimit
         }
       }


### PR DESCRIPTION
#52 の続き
Timerにidを付与していたが不要なので消去
それに伴い，各コンポーネントのidを消去
reducerを修正