### PR TITLE
resultの修正

### DIFF
--- a/src/scripts/village/actions/index.js
+++ b/src/scripts/village/actions/index.js
@@ -62,6 +62,10 @@ export const handleClickHideButton = (hide: boolean): {hide: boolean, type: 'CLI
   type: types.CLICK_HIDE_BUTTON
 })
 
+export const closeReuslt = (): {type: 'CLOSE_RESULT'} => ({
+  type: types.CLOSE_RESULT
+})
+
 export type SocketClose = $Call<typeof socket.close, *>
 export type SocketError = $Call<typeof socket.error, *>
 export type SocketMessage = $Call<typeof socket.message, *>
@@ -74,3 +78,4 @@ export type SelectOption = $Call<typeof selectOption, *>
 export type SelectNo = $Call<typeof selectNo, *>
 export type SelectYes = $Call<typeof selectYes, *>
 export type ClickHideButton = $Call<typeof handleClickHideButton, *>
+export type CloseReuslt = $Call<typeof closeReuslt>

--- a/src/scripts/village/components/Result.js
+++ b/src/scripts/village/components/Result.js
@@ -2,6 +2,7 @@
 import type {AgentStatus, TResult} from 'village'
 import React from 'react'
 import ResultCell from './ResultCell'
+import ResultClose from './ResultClose'
 
 export type StateProps = {
   +agents: {
@@ -23,9 +24,13 @@ export type StateProps = {
   +visible: boolean,
   +winners: string[]
 }
+export type DispatchProps = {
+  +handleClickCloseButton: void => void
+}
 export type OwnProps = {}
 export type Props =
   & StateProps
+  & DispatchProps
   & OwnProps
 
 const getRow = agent => [
@@ -120,9 +125,10 @@ export default function Result(props: Props) {
     <div className="result">
       {
         [
+          <ResultClose handleClick={props.handleClickCloseButton} key="close" />,
           <ResultCell key="summary" text={props.summary} type="summary" />,
           me,
-          <ResultCell key="caption winners" text="勝利者" type="caption" />,
+          <ResultCell key="caption winners" text="勝者" type="caption" />,
           ... winners,
           <ResultCell key="caption losers" text="敗者" type="caption" />,
           ... losers

--- a/src/scripts/village/components/Result.js
+++ b/src/scripts/village/components/Result.js
@@ -20,7 +20,11 @@ export type StateProps = {
   },
   +losers: string[],
   +me: ?string,
-  +summary: string,
+  +summary: {
+    +description: string,
+    +loser: string,
+    +winner: string
+  },
   +visible: boolean,
   +winners: string[]
 }
@@ -126,11 +130,11 @@ export default function Result(props: Props) {
       {
         [
           <ResultClose handleClick={props.handleClickCloseButton} key="close" />,
-          <ResultCell key="summary" text={props.summary} type="summary" />,
+          <ResultCell key="summary" text={props.summary.description} type="summary" />,
           me,
-          <ResultCell key="caption winners" text="勝者" type="caption" />,
+          <ResultCell key="caption winners" text={props.summary.winner} type="caption" />,
           ... winners,
-          <ResultCell key="caption losers" text="敗者" type="caption" />,
+          <ResultCell key="caption losers" text={props.summary.loser} type="caption" />,
           ... losers
         ]
       }

--- a/src/scripts/village/components/Result.test.js
+++ b/src/scripts/village/components/Result.test.js
@@ -156,6 +156,11 @@ const losers = [
   'agent6'
 ]
 const me = 'agent0'
+const summary = {
+  description: 'description',
+  loser: 'loser',
+  winner: 'winner'
+}
 const winners = [
   'agent0',
   'agent2',
@@ -176,7 +181,7 @@ test('<Result visible />', () => {
       handleClickCloseButton={handleClickCloseButton}
       losers={losers}
       me={me}
-      summary="summary"
+      summary={summary}
       visible
       winners={winners}
     />
@@ -193,7 +198,7 @@ test('<Result visible={false} />', () => {
       handleClickCloseButton={handleClickCloseButton}
       losers={losers}
       me={me}
-      summary="summary"
+      summary={summary}
       visible={false}
       winners={winners}
     />

--- a/src/scripts/village/components/Result.test.js
+++ b/src/scripts/village/components/Result.test.js
@@ -169,9 +169,11 @@ const winners = [
 ]
 
 test('<Result visible />', () => {
+  const handleClickCloseButton = jest.fn()
   const wrapper = shallow(
     <Result
       agents={agents}
+      handleClickCloseButton={handleClickCloseButton}
       losers={losers}
       me={me}
       summary="summary"
@@ -180,12 +182,15 @@ test('<Result visible />', () => {
     />
   )
 
+  expect(handleClickCloseButton).toHaveBeenCalledTimes(0)
   expect(wrapper.find('.result').exists()).toBe(true)
 })
 test('<Result visible={false} />', () => {
+  const handleClickCloseButton = jest.fn()
   const wrapper = shallow(
     <Result
       agents={agents}
+      handleClickCloseButton={handleClickCloseButton}
       losers={losers}
       me={me}
       summary="summary"
@@ -194,5 +199,6 @@ test('<Result visible={false} />', () => {
     />
   )
 
+  expect(handleClickCloseButton).toHaveBeenCalledTimes(0)
   expect(wrapper.find('.result').exists()).toBe(false)
 })

--- a/src/scripts/village/components/Result.test.js
+++ b/src/scripts/village/components/Result.test.js
@@ -4,8 +4,8 @@ import React from 'react'
 import Result from './Result'
 import {shallow} from 'enzyme'
 
-const rows = [
-  {
+const agents = {
+  'agent0': {
     'agentId': 1,
     'agentImage': 'https://werewolf.world/image/0.1/Walter.jpg',
     'agentName': 'ヴァルター',
@@ -16,7 +16,7 @@ const rows = [
     'userAvatar': 'https://werewolf.world/image/0.1/Gert.jpg',
     'userName': 'Suzuki'
   },
-  {
+  'agent1': {
     'agentId': 2,
     'agentImage': 'https://werewolf.world/image/0.1/Moritz.jpg',
     'agentName': 'モーリッツ',
@@ -27,7 +27,7 @@ const rows = [
     'userAvatar': 'https://werewolf.world/image/0.1/Alvin.jpg',
     'userName': 'Takahashi'
   },
-  {
+  'agent2': {
     'agentId': 3,
     'agentImage': 'https://werewolf.world/image/0.1/Simson.jpg',
     'agentName': 'ジムゾン',
@@ -38,7 +38,7 @@ const rows = [
     'userAvatar': 'https://werewolf.world/image/0.1/Friedel.jpg',
     'userName': 'Tanaka'
   },
-  {
+  'agent3': {
     'agentId': 4,
     'agentImage': 'https://werewolf.world/image/0.1/Thomas.jpg',
     'agentName': 'トーマス',
@@ -49,7 +49,7 @@ const rows = [
     'userAvatar': 'https://werewolf.world/image/0.1/Dieter.jpg',
     'userName': 'Ito'
   },
-  {
+  'agent4': {
     'agentId': 5,
     'agentImage': 'https://werewolf.world/image/0.1/Nicholas.jpg',
     'agentName': 'ニコラス',
@@ -60,7 +60,7 @@ const rows = [
     'userName': 'Watanabe',
     'userAvatar': 'https://werewolf.world/image/0.1/Erna.jpg'
   },
-  {
+  'agent5': {
     'agentId': 6,
     'agentImage': 'https://werewolf.world/image/0.1/Dieter.jpg',
     'agentName': 'ディーター',
@@ -71,7 +71,7 @@ const rows = [
     'userName': 'Yamamoto',
     'userAvatar': 'https://werewolf.world/image/0.1/Jacob.jpg'
   },
-  {
+  'agent6': {
     'agentId': 7,
     'agentImage': 'https://werewolf.world/image/0.1/Peter.jpg',
     'agentName': 'ペーター',
@@ -82,7 +82,7 @@ const rows = [
     'userName': 'Nakamura',
     'userAvatar': 'https://werewolf.world/image/0.1/Nicholas.jpg'
   },
-  {
+  'agent7': {
     'agentImage': 'https://werewolf.world/image/0.1/Lisa.jpg',
     'agentName': 'リーザ',
     'agentId': 8,
@@ -93,7 +93,7 @@ const rows = [
     'userAvatar': 'https://werewolf.world/image/0.1/Peter.jpg',
     'userName': 'Kobayashi'
   },
-  {
+  'agent8': {
     'agentId': 9,
     'agentImage': 'https://werewolf.world/image/0.1/Alvin.jpg',
     'agentName': 'アルビン',
@@ -104,7 +104,7 @@ const rows = [
     'userAvatar': 'https://werewolf.world/image/0.1/Peter.jpg',
     'userName': 'Yoshida'
   },
-  {
+  'agent9': {
     'agentId': 11,
     'agentImage': 'https://werewolf.world/image/0.1/Otto.jpg',
     'agentName': 'オットー',
@@ -115,7 +115,7 @@ const rows = [
     'userAvatar': 'https://werewolf.world/image/0.1/Simson.jpg',
     'userName': 'Sasaki'
   },
-  {
+  'agent10': {
     'agentId': 12,
     'agentImage': 'https://werewolf.world/image/0.1/Joachim.jpg',
     'agentName': 'ヨアヒム',
@@ -126,7 +126,7 @@ const rows = [
     'userAvatar': 'https://werewolf.world/image/0.1/Otto.jpg',
     'userName': '山口'
   },
-  {
+  'agent11': {
     'agentName': 'パメラ',
     'agentImage': 'https://werewolf.world/image/0.1/Pamela.jpg',
     'agentId': 13,
@@ -137,7 +137,7 @@ const rows = [
     'userAvatar': 'https://werewolf.world/image/0.1/Joachim.jpg',
     'userName': '松本'
   },
-  {
+  'agent12': {
     'agentId': 14,
     'agentImage': 'https://werewolf.world/image/0.1/Jacob.jpg',
     'agentName': 'ヤコブ',
@@ -148,15 +148,51 @@ const rows = [
     'userAvatar': 'https://werewolf.world/image/0.1/Catalina.jpg',
     'userName': '井上'
   }
+}
+const losers = [
+  'agent1',
+  'agent4',
+  'agent5',
+  'agent6'
+]
+const me = 'agent0'
+const winners = [
+  'agent0',
+  'agent2',
+  'agent3',
+  'agent7',
+  'agent8',
+  'agent9',
+  'agent10',
+  'agent11',
+  'agent12'
 ]
 
 test('<Result visible />', () => {
-  const wrapper = shallow(<Result rows={rows} summary="summary" visible />)
+  const wrapper = shallow(
+    <Result
+      agents={agents}
+      losers={losers}
+      me={me}
+      summary="summary"
+      visible
+      winners={winners}
+    />
+  )
 
   expect(wrapper.find('.result').exists()).toBe(true)
 })
 test('<Result visible={false} />', () => {
-  const wrapper = shallow(<Result rows={rows} summary="summary" visible={false} />)
+  const wrapper = shallow(
+    <Result
+      agents={agents}
+      losers={losers}
+      me={me}
+      summary="summary"
+      visible={false}
+      winners={winners}
+    />
+  )
 
   expect(wrapper.find('.result').exists()).toBe(false)
 })

--- a/src/scripts/village/components/ResultCell.js
+++ b/src/scripts/village/components/ResultCell.js
@@ -1,30 +1,27 @@
 // @flow
-import type {AgentStatus, Result} from 'village'
+import type {AgentStatus} from 'village'
 import React from 'react'
 
 type Props =
   | {
     +image: string,
-    +result: Result,
     +status: AgentStatus,
     +type: 'image' | 'userAvatar'
   }
   | {
     +image: string,
-    +result: Result,
     +status: AgentStatus,
     +tooltip: string,
     +type: 'roleImage'
   }
   | {
     +text: string,
-    +type: 'summary'
+    +type: 'caption' | 'summary'
   }
   | {
-    +result: Result,
     +status: AgentStatus,
     +text: string,
-    +type: 'name' | 'result' | 'status' | 'userName'
+    +type: 'name' | 'status' | 'userName'
   }
 
 export default function ResultCell(props: Props) {
@@ -32,16 +29,17 @@ export default function ResultCell(props: Props) {
     case 'image':
     case 'userAvatar':
       return (
-        <div className={`result--cell ${props.status === 'alive' ? '' : 'dead'} ${props.result === 'win' ? 'win' : ''}`} data-result={props.type}>
+        <div className={`result--cell ${props.status === 'alive' ? '' : 'dead'}`} data-result={props.type}>
           <img src={props.image} />
         </div>
       )
     case 'roleImage':
       return (
-        <div className={`result--cell ${props.status === 'alive' ? '' : 'dead'} ${props.result === 'win' ? 'win' : ''}`} data-result={props.type} data-tooltip={props.tooltip}>
+        <div className={`result--cell ${props.status === 'alive' ? '' : 'dead'}`} data-result={props.type} data-tooltip={props.tooltip}>
           <img src={props.image} />
         </div>
       )
+    case 'caption':
     case 'summary':
       return (
         <div className="result--cell" data-result={props.type}>
@@ -49,11 +47,10 @@ export default function ResultCell(props: Props) {
         </div>
       )
     case 'name':
-    case 'result':
     case 'status':
     case 'userName':
       return (
-        <div className={`result--cell ${props.status === 'alive' ? '' : 'dead'} ${props.result === 'win' ? 'win' : ''}`} data-result={props.type}>
+        <div className={`result--cell ${props.status === 'alive' ? '' : 'dead'}`} data-result={props.type}>
           {props.text}
         </div>
       )

--- a/src/scripts/village/components/ResultCell.test.js
+++ b/src/scripts/village/components/ResultCell.test.js
@@ -3,661 +3,179 @@ import React from 'react'
 import ResultCell from './ResultCell'
 import {shallow} from 'enzyme'
 
-test('<ResultCell image="image" result="win" status="alive" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="alive" type="image" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="alive"
-      text="text"
-      tooltip="tooltip"
       type="image"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="dead" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="dead" type="image" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="dead"
-      text="text"
-      tooltip="tooltip"
       type="image"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="death by execution" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="death by execution" type="image" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="death by execution"
-      text="text"
-      tooltip="tooltip"
       type="image"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="death by werewolf attack" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="death by werewolf attack" type="image" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="death by werewolf attack"
-      text="text"
-      tooltip="tooltip"
       type="image"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="death by fear" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="death by fear" type="image" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="death by fear"
-      text="text"
-      tooltip="tooltip"
       type="image"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="unnatural death" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="unnatural death" type="image" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="unnatural death"
-      text="text"
-      tooltip="tooltip"
       type="image"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="lose" status="alive" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="alive" type="userAvatar" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="lose"
       status="alive"
-      text="text"
-      tooltip="tooltip"
-      type="image"
+      type="userAvatar"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="lose" status="dead" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="dead" type="userAvatar" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="lose"
       status="dead"
-      text="text"
-      tooltip="tooltip"
-      type="image"
+      type="userAvatar"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="lose" status="death by execution" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="death by execution" type="userAvatar" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="lose"
       status="death by execution"
-      text="text"
-      tooltip="tooltip"
-      type="image"
+      type="userAvatar"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="lose" status="death by werewolf attack" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="death by werewolf attack" type="userAvatar" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="lose"
       status="death by werewolf attack"
-      text="text"
-      tooltip="tooltip"
-      type="image"
+      type="userAvatar"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="lose" status="death by fear" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="death by fear" type="userAvatar" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="lose"
       status="death by fear"
-      text="text"
-      tooltip="tooltip"
-      type="image"
+      type="userAvatar"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="lose" status="unnatural death" text="text" tooltip="tooltip" type="image" />', () => {
+test('<ResultCell image="image" status="unnatural death" type="userAvatar" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="lose"
       status="unnatural death"
-      text="text"
-      tooltip="tooltip"
-      type="image"
+      type="userAvatar"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="image"]')).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="alive" text="text" tooltip="tooltip" type="name" />', () => {
+test('<ResultCell image="image" status="alive" tooltip="tooltip" type="roleImage" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="alive"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="dead" text="text" tooltip="tooltip" type="name" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="dead"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="death by execution" text="text" tooltip="tooltip" type="name" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="death by execution"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="death by werewolf attack" text="text" tooltip="tooltip" type="name" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="death by werewolf attack"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="death by fear" text="text" tooltip="tooltip" type="name" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="death by fear"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="unnatural death" text="text" tooltip="tooltip" type="name" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="unnatural death"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="alive" text="text" tooltip="tooltip" type="name" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="alive"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="dead" text="text" tooltip="tooltip" type="name" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="dead"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by execution" text="text" tooltip="tooltip" type="name" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by execution"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by werewolf attack" text="text" tooltip="tooltip" type="name" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by werewolf attack"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by fear" text="text" tooltip="tooltip" type="name" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by fear"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="unnatural death" text="text" tooltip="tooltip" type="name" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="unnatural death"
-      text="text"
-      tooltip="tooltip"
-      type="name"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="alive" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="alive"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="dead" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="dead"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="death by execution" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="death by execution"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="death by werewolf attack" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="death by werewolf attack"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="death by fear" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="death by fear"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="unnatural death" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="unnatural death"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="alive" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="alive"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="dead" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="dead"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by execution" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by execution"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by werewolf attack" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by werewolf attack"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by fear" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by fear"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="unnatural death" text="text" tooltip="tooltip" type="result" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="unnatural death"
-      text="text"
-      tooltip="tooltip"
-      type="result"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="result"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="alive" text="text" tooltip="tooltip" type="roleImage" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="alive"
-      text="text"
       tooltip="tooltip"
       type="roleImage"
     />
@@ -665,18 +183,15 @@ test('<ResultCell image="image" result="win" status="alive" text="text" tooltip=
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="dead" text="text" tooltip="tooltip" type="roleImage" />', () => {
+test('<ResultCell image="image" status="dead" tooltip="tooltip" type="roleImage" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="dead"
-      text="text"
       tooltip="tooltip"
       type="roleImage"
     />
@@ -684,18 +199,15 @@ test('<ResultCell image="image" result="win" status="dead" text="text" tooltip="
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="death by execution" text="text" tooltip="tooltip" type="roleImage" />', () => {
+test('<ResultCell image="image" status="death by execution" tooltip="tooltip" type="roleImage" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="death by execution"
-      text="text"
       tooltip="tooltip"
       type="roleImage"
     />
@@ -703,18 +215,15 @@ test('<ResultCell image="image" result="win" status="death by execution" text="t
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="death by werewolf attack" text="text" tooltip="tooltip" type="roleImage" />', () => {
+test('<ResultCell image="image" status="death by werewolf attack" tooltip="tooltip" type="roleImage" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="death by werewolf attack"
-      text="text"
       tooltip="tooltip"
       type="roleImage"
     />
@@ -722,18 +231,15 @@ test('<ResultCell image="image" result="win" status="death by werewolf attack" t
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="death by fear" text="text" tooltip="tooltip" type="roleImage" />', () => {
+test('<ResultCell image="image" status="death by fear" tooltip="tooltip" type="roleImage" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="death by fear"
-      text="text"
       tooltip="tooltip"
       type="roleImage"
     />
@@ -741,18 +247,15 @@ test('<ResultCell image="image" result="win" status="death by fear" text="text" 
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="unnatural death" text="text" tooltip="tooltip" type="roleImage" />', () => {
+test('<ResultCell image="image" status="unnatural death" tooltip="tooltip" type="roleImage" />', () => {
   const wrapper = shallow(
     <ResultCell
       image="image"
-      result="win"
       status="unnatural death"
-      text="text"
       tooltip="tooltip"
       type="roleImage"
     />
@@ -760,340 +263,9 @@ test('<ResultCell image="image" result="win" status="unnatural death" text="text
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
   expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
-})
-test('<ResultCell image="image" result="lose" status="alive" text="text" tooltip="tooltip" type="roleImage" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="alive"
-      text="text"
-      tooltip="tooltip"
-      type="roleImage"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
-})
-test('<ResultCell image="image" result="lose" status="dead" text="text" tooltip="tooltip" type="roleImage" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="dead"
-      text="text"
-      tooltip="tooltip"
-      type="roleImage"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
-})
-test('<ResultCell image="image" result="lose" status="death by execution" text="text" tooltip="tooltip" type="roleImage" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by execution"
-      text="text"
-      tooltip="tooltip"
-      type="roleImage"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
-})
-test('<ResultCell image="image" result="lose" status="death by werewolf attack" text="text" tooltip="tooltip" type="roleImage" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by werewolf attack"
-      text="text"
-      tooltip="tooltip"
-      type="roleImage"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
-})
-test('<ResultCell image="image" result="lose" status="death by fear" text="text" tooltip="tooltip" type="roleImage" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by fear"
-      text="text"
-      tooltip="tooltip"
-      type="roleImage"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
-})
-test('<ResultCell image="image" result="lose" status="unnatural death" text="text" tooltip="tooltip" type="roleImage" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="unnatural death"
-      text="text"
-      tooltip="tooltip"
-      type="roleImage"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="roleImage"]')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-tooltip="tooltip"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
-})
-test('<ResultCell image="image" result="win" status="alive" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="alive"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="dead" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="dead"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="death by execution" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="death by execution"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="death by werewolf attack" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="death by werewolf attack"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="death by fear" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="death by fear"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="win" status="unnatural death" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="win"
-      status="unnatural death"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="alive" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="alive"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="dead" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="dead"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by execution" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by execution"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by werewolf attack" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by werewolf attack"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by fear" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by fear"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="unnatural death" text="text" tooltip="tooltip" type="status" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="unnatural death"
-      text="text"
-      tooltip="tooltip"
-      type="status"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
 })
 test('<ResultCell text="text" type="summary" />', () => {
   const wrapper = shallow(
@@ -1110,435 +282,270 @@ test('<ResultCell text="text" type="summary" />', () => {
     </div>
   )).toBe(true)
 })
-test('<ResultCell image="image" result="win" status="alive" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell text="text" type="caption" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
+      text="text"
+      type="caption"
+    />
+  )
+
+  expect(wrapper.find('.result--cell').exists()).toBe(true)
+  expect(wrapper.equals(
+    <div className="result--cell" data-result="caption">
+      {'text'}
+    </div>
+  )).toBe(true)
+})
+test('<ResultCell status="alive" text="text" type="name" />', () => {
+  const wrapper = shallow(
+    <ResultCell
       status="alive"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="name"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="win" status="dead" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell status="dead" text="text" type="name" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
       status="dead"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="name"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="win" status="death by execution" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell status="death by execution" text="text" type="name" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
       status="death by execution"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="name"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="win" status="death by werewolf attack" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell status="death by werewolf attack" text="text" type="name" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
       status="death by werewolf attack"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="name"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="win" status="death by fear" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell status="death by fear" text="text" type="name" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
       status="death by fear"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="name"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="win" status="unnatural death" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell status="unnatural death" text="text" type="name" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
       status="unnatural death"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="name"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="name"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="lose" status="alive" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell status="alive" text="text" type="status" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="lose"
       status="alive"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="status"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="lose" status="dead" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell status="dead" text="text" type="status" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="lose"
       status="dead"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="status"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="lose" status="death by execution" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell status="death by execution" text="text" type="status" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="lose"
       status="death by execution"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="status"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="lose" status="death by werewolf attack" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell status="death by werewolf attack" text="text" type="status" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="lose"
       status="death by werewolf attack"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="status"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="lose" status="death by fear" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell status="death by fear" text="text" type="status" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="lose"
       status="death by fear"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="status"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="lose" status="unnatural death" text="text" tooltip="tooltip" type="userAvatar" />', () => {
+test('<ResultCell status="unnatural death" text="text" type="status" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="lose"
       status="unnatural death"
       text="text"
-      tooltip="tooltip"
-      type="userAvatar"
+      type="status"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="userAvatar"]')).toBe(true)
-  expect(wrapper.containsMatchingElement(<img src="image" />)).toBe(true)
+  expect(wrapper.find('.result--cell').is('[data-result="status"]')).toBe(true)
+  expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="win" status="alive" text="text" tooltip="tooltip" type="userName" />', () => {
+test('<ResultCell status="alive" text="text" type="userName" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
       status="alive"
       text="text"
-      tooltip="tooltip"
       type="userName"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
   expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="win" status="dead" text="text" tooltip="tooltip" type="userName" />', () => {
+test('<ResultCell status="dead" text="text" type="userName" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
       status="dead"
       text="text"
-      tooltip="tooltip"
       type="userName"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
   expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="win" status="death by execution" text="text" tooltip="tooltip" type="userName" />', () => {
+test('<ResultCell status="death by execution" text="text" type="userName" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
       status="death by execution"
       text="text"
-      tooltip="tooltip"
       type="userName"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
   expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="win" status="death by werewolf attack" text="text" tooltip="tooltip" type="userName" />', () => {
+test('<ResultCell status="death by werewolf attack" text="text" type="userName" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
       status="death by werewolf attack"
       text="text"
-      tooltip="tooltip"
       type="userName"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
   expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="win" status="death by fear" text="text" tooltip="tooltip" type="userName" />', () => {
+test('<ResultCell status="death by fear" text="text" type="userName" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
       status="death by fear"
       text="text"
-      tooltip="tooltip"
       type="userName"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
   expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
   expect(wrapper.text()).toBe('text')
 })
-test('<ResultCell image="image" result="win" status="unnatural death" text="text" tooltip="tooltip" type="userName" />', () => {
+test('<ResultCell status="unnatural death" text="text" type="userName" />', () => {
   const wrapper = shallow(
     <ResultCell
-      image="image"
-      result="win"
       status="unnatural death"
       text="text"
-      tooltip="tooltip"
       type="userName"
     />
   )
 
   expect(wrapper.find('.result--cell').exists()).toBe(true)
   expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(true)
-  expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="alive" text="text" tooltip="tooltip" type="userName" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="alive"
-      text="text"
-      tooltip="tooltip"
-      type="userName"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(false)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="dead" text="text" tooltip="tooltip" type="userName" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="dead"
-      text="text"
-      tooltip="tooltip"
-      type="userName"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by execution" text="text" tooltip="tooltip" type="userName" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by execution"
-      text="text"
-      tooltip="tooltip"
-      type="userName"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by werewolf attack" text="text" tooltip="tooltip" type="userName" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by werewolf attack"
-      text="text"
-      tooltip="tooltip"
-      type="userName"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="death by fear" text="text" tooltip="tooltip" type="userName" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="death by fear"
-      text="text"
-      tooltip="tooltip"
-      type="userName"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
-  expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
-  expect(wrapper.text()).toBe('text')
-})
-test('<ResultCell image="image" result="lose" status="unnatural death" text="text" tooltip="tooltip" type="userName" />', () => {
-  const wrapper = shallow(
-    <ResultCell
-      image="image"
-      result="lose"
-      status="unnatural death"
-      text="text"
-      tooltip="tooltip"
-      type="userName"
-    />
-  )
-
-  expect(wrapper.find('.result--cell').exists()).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('dead')).toBe(true)
-  expect(wrapper.find('.result--cell').hasClass('win')).toBe(false)
   expect(wrapper.find('.result--cell').is('[data-result="userName"]')).toBe(true)
   expect(wrapper.text()).toBe('text')
 })

--- a/src/scripts/village/components/ResultClose.js
+++ b/src/scripts/village/components/ResultClose.js
@@ -1,0 +1,19 @@
+// @flow
+import React from 'react'
+
+type Props = {
+  +handleClick: void => void
+}
+
+export default function ResultClose(props: Props) {
+  return (
+    <div className="result--close" onClick={props.handleClick}>
+      <svg viewBox="0 0 24 24">
+        <path
+          d="M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2C6.47,2 2,6.47 2,12C2,17.53 6.47,22 12,22C17.53,22 22,17.53 22,12C22,6.47 17.53,2 12,2M14.59,8L12,10.59L9.41,8L8,9.41L10.59,12L8,14.59L9.41,16L12,13.41L14.59,16L16,14.59L13.41,12L16,9.41L14.59,8Z"
+          fill="#000000"
+        />
+      </svg>
+    </div>
+  )
+}

--- a/src/scripts/village/components/ResultClose.test.js
+++ b/src/scripts/village/components/ResultClose.test.js
@@ -1,0 +1,12 @@
+// @flow
+import React from 'react'
+import ResultClose from './ResultClose'
+import {shallow} from 'enzyme'
+
+test('<ResultClose class="class" text="text" />', () => {
+  const handleClick = jest.fn()
+  const wrapper = shallow(<ResultClose handleClick={handleClick} />)
+
+  expect(handleClick).toHaveBeenCalledTimes(0)
+  expect(wrapper.exists()).toBe(true)
+})

--- a/src/scripts/village/constants/ActionTypes.js
+++ b/src/scripts/village/constants/ActionTypes.js
@@ -1,6 +1,7 @@
 // @flow
 export const CHANGE_PREDICTION_BOARD = 'CHANGE_PREDICTION_BOARD'
 export const CLICK_HIDE_BUTTON = 'CLICK_HIDE_BUTTON'
+export const CLOSE_RESULT = 'CLOSE_RESULT'
 export const GET_PLAYER_ROLE = 'GET_PLAYER_ROLE'
 export const PROLOGUE = 'PROLOGUE'
 export const POST_CHAT = 'POST_CHAT'

--- a/src/scripts/village/containers/ResultContainer.js
+++ b/src/scripts/village/containers/ResultContainer.js
@@ -6,17 +6,23 @@ import {connect} from 'react-redux'
 import {xor} from '../util'
 
 const mapStateToProps = (state: ReducerState): StateProps => {
-  const rows = state.result.agents.map(a => ({
-    agentId: a.agentId,
-    agentImage: a.agentImage,
-    agentName: a.agentName.ja,
-    result: a.result,
-    roleImage: a.roleImage,
-    roleName: a.roleName.ja,
-    status: a.status,
-    userAvatar: a.userAvatar,
-    userName: a.userName
-  }))
+  const agents = {}
+
+  state.result.allIds.forEach(id => {
+    const a = state.result.agents[id]
+
+    agents[id] = {
+      agentId: a.agentId,
+      agentImage: a.agentImage,
+      agentName: a.agentName.ja,
+      result: a.result,
+      roleImage: a.roleImage,
+      roleName: a.roleName.ja,
+      status: a.status,
+      userAvatar: a.userAvatar,
+      userName: a.userName
+    }
+  })
   const summary = (() => {
     const isWerewolfSide = WEREWOLF_SIDE.includes(state.result.summary.role)
     const isWin = state.result.summary.result === 'win'
@@ -32,9 +38,12 @@ const mapStateToProps = (state: ReducerState): StateProps => {
   })()
 
   return {
-    rows,
+    agents,
+    losers: state.result.losers,
+    me: state.result.me,
     summary,
-    visible: state.result.visible
+    visible: state.result.visible,
+    winners: state.result.winners
   }
 }
 const ResultContainer = connect(

--- a/src/scripts/village/containers/ResultContainer.js
+++ b/src/scripts/village/containers/ResultContainer.js
@@ -1,11 +1,11 @@
 // @flow
+import {type CloseReuslt, closeReuslt} from '../actions'
 import Result, {type DispatchProps, type StateProps} from '../components/Result'
-import type {ReducerState} from '../reducers'
 import type {Dispatch} from 'redux'
+import type {ReducerState} from '../reducers'
 import {WEREWOLF_SIDE} from '../constants/Role'
 import {connect} from 'react-redux'
 import {xor} from '../util'
-import {type CloseReuslt, closeReuslt} from '../actions';
 
 type Action =
   | CloseReuslt

--- a/src/scripts/village/containers/ResultContainer.js
+++ b/src/scripts/village/containers/ResultContainer.js
@@ -1,9 +1,14 @@
 // @flow
-import Result, {type StateProps} from '../components/Result'
+import Result, {type DispatchProps, type StateProps} from '../components/Result'
 import type {ReducerState} from '../reducers'
+import type {Dispatch} from 'redux'
 import {WEREWOLF_SIDE} from '../constants/Role'
 import {connect} from 'react-redux'
 import {xor} from '../util'
+import {type CloseReuslt, closeReuslt} from '../actions';
+
+type Action =
+  | CloseReuslt
 
 const mapStateToProps = (state: ReducerState): StateProps => {
   const agents = {}
@@ -46,8 +51,14 @@ const mapStateToProps = (state: ReducerState): StateProps => {
     winners: state.result.winners
   }
 }
+const mapDispatchToProps = (dispatch: Dispatch<Action>): DispatchProps => ({
+  handleClickCloseButton: () => {
+    dispatch(closeReuslt())
+  }
+})
 const ResultContainer = connect(
-  mapStateToProps
+  mapStateToProps,
+  mapDispatchToProps
 )(Result)
 
 export default ResultContainer

--- a/src/scripts/village/containers/ResultContainer.js
+++ b/src/scripts/village/containers/ResultContainer.js
@@ -31,15 +31,27 @@ const mapStateToProps = (state: ReducerState): StateProps => {
   const summary = (() => {
     const isWerewolfSide = WEREWOLF_SIDE.includes(state.result.summary.role)
     const isWin = state.result.summary.result === 'win'
+    const description = (() => {
+      if (state.result.summary.isPlayer) {
+        return `人間側の${xor(isWerewolfSide, isWin) ? '勝利' : '敗北'}のため，あなたは${isWin ? '勝ち' : '負け'}ました`
+      }
 
-    if (state.result.summary.isPlayer) {
-      const text = `人間側の${xor(isWerewolfSide, isWin) ? '勝利' : '敗北'}のため，あなたは${isWin ? '勝ち' : '負け'}ました`
+      return `人間側が${xor(isWerewolfSide, isWin) ? '勝利' : '敗北'}しました`
+    })()
 
-      return text
+    if (xor(isWerewolfSide, isWin)) {
+      return {
+        description,
+        loser: '敗者（人狼チーム）',
+        winner: '勝者（人間チーム）'
+      }
     }
-    const text = `人間側が${xor(isWerewolfSide, isWin) ? '勝利' : '敗北'}しました`
 
-    return text
+    return {
+      description,
+      loser: '敗者（人間チーム）',
+      winner: '勝者（人狼チーム）'
+    }
   })()
 
   return {

--- a/src/scripts/village/reducers/result.test.js
+++ b/src/scripts/village/reducers/result.test.js
@@ -25,8 +25,8 @@ test('SOCKET_MESSAGE phase is results', () => {
       }
     )
   ).toEqual({
-    agents: [
-      {
+    agents: {
+      'agent0': {
         'agentId': 1,
         'agentImage': 'https://werewolf.world/image/0.1/Walter.jpg',
         'agentName': {
@@ -43,7 +43,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userAvatar': 'https://werewolf.world/image/0.1/Gert.jpg',
         'userName': 'Suzuki'
       },
-      {
+      'agent1': {
         'agentId': 2,
         'agentImage': 'https://werewolf.world/image/0.1/Moritz.jpg',
         'agentName': {
@@ -60,7 +60,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userAvatar': 'https://werewolf.world/image/0.1/Alvin.jpg',
         'userName': 'Takahashi'
       },
-      {
+      'agent2': {
         'agentId': 3,
         'agentImage': 'https://werewolf.world/image/0.1/Simson.jpg',
         'agentName': {
@@ -77,7 +77,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userAvatar': 'https://werewolf.world/image/0.1/Friedel.jpg',
         'userName': 'Tanaka'
       },
-      {
+      'agent3': {
         'agentId': 4,
         'agentImage': 'https://werewolf.world/image/0.1/Thomas.jpg',
         'agentName': {
@@ -94,7 +94,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userAvatar': 'https://werewolf.world/image/0.1/Dieter.jpg',
         'userName': 'Ito'
       },
-      {
+      'agent4': {
         'agentId': 5,
         'agentImage': 'https://werewolf.world/image/0.1/Nicholas.jpg',
         'agentName': {
@@ -111,7 +111,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userName': 'Watanabe',
         'userAvatar': 'https://werewolf.world/image/0.1/Erna.jpg'
       },
-      {
+      'agent5': {
         'agentId': 6,
         'agentImage': 'https://werewolf.world/image/0.1/Dieter.jpg',
         'agentName': {
@@ -128,7 +128,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userName': 'Yamamoto',
         'userAvatar': 'https://werewolf.world/image/0.1/Jacob.jpg'
       },
-      {
+      'agent6': {
         'agentId': 7,
         'agentImage': 'https://werewolf.world/image/0.1/Peter.jpg',
         'agentName': {
@@ -145,7 +145,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userName': 'Nakamura',
         'userAvatar': 'https://werewolf.world/image/0.1/Nicholas.jpg'
       },
-      {
+      'agent7': {
         'agentImage': 'https://werewolf.world/image/0.1/Lisa.jpg',
         'agentName': {
           'en': 'Lisa',
@@ -162,7 +162,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userAvatar': 'https://werewolf.world/image/0.1/Peter.jpg',
         'userName': 'Kobayashi'
       },
-      {
+      'agent8': {
         'agentId': 9,
         'agentImage': 'https://werewolf.world/image/0.1/Alvin.jpg',
         'agentName': {
@@ -179,7 +179,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userAvatar': 'https://werewolf.world/image/0.1/Peter.jpg',
         'userName': 'Yoshida'
       },
-      {
+      'agent9': {
         'agentId': 11,
         'agentImage': 'https://werewolf.world/image/0.1/Otto.jpg',
         'agentName': {
@@ -196,7 +196,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userAvatar': 'https://werewolf.world/image/0.1/Simson.jpg',
         'userName': 'Sasaki'
       },
-      {
+      'agent10': {
         'agentId': 12,
         'agentImage': 'https://werewolf.world/image/0.1/Joachim.jpg',
         'agentName': {
@@ -213,7 +213,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userAvatar': 'https://werewolf.world/image/0.1/Otto.jpg',
         'userName': '山口'
       },
-      {
+      'agent11': {
         'agentName': {
           'en': 'Pamela',
           'ja': 'パメラ'
@@ -230,7 +230,7 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userAvatar': 'https://werewolf.world/image/0.1/Joachim.jpg',
         'userName': '松本'
       },
-      {
+      'agent12': {
         'agentId': 14,
         'agentImage': 'https://werewolf.world/image/0.1/Jacob.jpg',
         'agentName': {
@@ -247,13 +247,46 @@ test('SOCKET_MESSAGE phase is results', () => {
         'userAvatar': 'https://werewolf.world/image/0.1/Catalina.jpg',
         'userName': '井上'
       }
+    },
+    allIds: [
+      'agent0',
+      'agent1',
+      'agent2',
+      'agent3',
+      'agent4',
+      'agent5',
+      'agent6',
+      'agent7',
+      'agent8',
+      'agent9',
+      'agent10',
+      'agent11',
+      'agent12'
     ],
+    losers: [
+      'agent1',
+      'agent4',
+      'agent5',
+      'agent6'
+    ],
+    me: 'agent0',
     summary: {
       isPlayer: true,
       result: 'win',
       role: 'https://werewolf.world/resource/0.1/seer'
     },
-    visible: true
+    visible: true,
+    winners: [
+      'agent0',
+      'agent2',
+      'agent3',
+      'agent7',
+      'agent8',
+      'agent9',
+      'agent10',
+      'agent11',
+      'agent12'
+    ]
   })
 })
 

--- a/src/scripts/village/util/index.js
+++ b/src/scripts/village/util/index.js
@@ -2,6 +2,19 @@
 import {UNPLAYABLE_AGENT} from '../constants/Agent'
 import {UNPLAYABLE_ROLE} from '../constants/Role'
 
+export const idGenerater = (prefix: string) => {
+  let chatId
+
+  return () => {
+    if (chatId === undefined) {
+      chatId = -1
+    }
+    chatId += 1
+
+    return `${prefix}${chatId}`
+  }
+}
+
 export const getPlayableAgents = <T: {'@id': string}>(agents: T[]): T[] =>
   agents.filter(a => !UNPLAYABLE_AGENT.includes(a['@id']))
 

--- a/src/scripts/village/util/index.test.js
+++ b/src/scripts/village/util/index.test.js
@@ -1,7 +1,202 @@
 // @flow
 /* eslint sort-keys: 0 */
-import {getMyAgent, getMyRole, getPlayableAgents, getPlayableRoles,trimBaseUri, xor} from './index'
+import {getMyAgent, getMyRole, getPlayableAgents, getPlayableRoles, idGenerater, trimBaseUri, xor} from './index'
 
+test('getMyAgent', () => {
+  const agents = [
+    {
+      '@id': 'https://werewolf.world/resource/0.1/Gert',
+      'agentIsMine': false,
+      'name': {
+        'en': 'Gert',
+        'ja': 'ゲルト'
+      },
+      'image': 'https://werewolf.world/image/0.1/Gert.jpg',
+      'id': 0,
+      'status': 'alive',
+      'statusUpdatePhase': 'day conversation',
+      'statusUpdateDate': 1,
+      'isAChoice': false
+    },
+    {
+      '@id': 'https://werewolf.world/resource/0.1/Walter',
+      'agentIsMine': true,
+      'name': {
+        'en': 'Walter',
+        'ja': 'ヴァルター'
+      },
+      'image': 'https://werewolf.world/image/0.1/Walter.jpg',
+      'id': 1,
+      'status': 'alive',
+      'statusUpdatePhase': 'day conversation',
+      'statusUpdateDate': 1,
+      'isAChoice': false
+    },
+    {
+      '@id': 'https://werewolf.world/resource/0.1/Catalina',
+      'agentIsMine': false,
+      'name': {
+        'en': 'Catalina',
+        'ja': 'カタリナ'
+      },
+      'image': 'https://werewolf.world/image/0.1/Catalina.jpg',
+      'id': 10,
+      'status': 'alive',
+      'statusUpdatePhase': 'day conversation',
+      'statusUpdateDate': 1,
+      'isAChoice': false
+    },
+    {
+      '@id': 'https://werewolf.world/resource/0.1/Otto',
+      'agentIsMine': false,
+      'name': {
+        'en': 'Otto',
+        'ja': 'オットー'
+      },
+      'image': 'https://werewolf.world/image/0.1/Otto.jpg',
+      'id': 11,
+      'status': 'alive',
+      'statusUpdatePhase': 'day conversation',
+      'statusUpdateDate': 1,
+      'isAChoice': false
+    }
+  ]
+
+  expect(getMyAgent(agents)).toEqual({
+    '@id': 'https://werewolf.world/resource/0.1/Walter',
+    'agentIsMine': true,
+    'name': {
+      'en': 'Walter',
+      'ja': 'ヴァルター'
+    },
+    'image': 'https://werewolf.world/image/0.1/Walter.jpg',
+    'id': 1,
+    'status': 'alive',
+    'statusUpdatePhase': 'day conversation',
+    'statusUpdateDate': 1,
+    'isAChoice': false
+  })
+})
+test('getMyRole', () => {
+  const roles = [
+    {
+      '@id': 'https://werewolf.world/resource/0.1/master',
+      'roleIsMine': false,
+      'name': {
+        'en': 'Master',
+        'ja': 'マスター'
+      },
+      'image': 'https://werewolf.world/image/0.1/master.jpg',
+      'numberOfAgents': 1,
+      'board': []
+    },
+    {
+      '@id': 'https://werewolf.world/resource/0.1/villager',
+      'roleIsMine': false,
+      'name': {
+        'en': 'Villager',
+        'ja': '村人'
+      },
+      'image': 'https://werewolf.world/image/0.1/villager.jpg',
+      'numberOfAgents': 6,
+      'board': [
+        {
+          'boardAgent': {
+            '@id': 'https://werewolf.world/resource/0.1/Walter',
+            'boardAgentId': 1,
+            'boardAgentName': {
+              'en': 'Walter',
+              'ja': 'ヴァルター'
+            },
+            'boardAgentImage': 'https://werewolf.world/image/0.1/Walter.jpg'
+          },
+          'boardPolarity': 'negative',
+          'boardPhase': 'day conversation',
+          'boardDate': 1
+        }
+      ]
+    },
+    {
+      '@id': 'https://werewolf.world/resource/0.1/seer',
+      'roleIsMine': true,
+      'name': {
+        'en': 'Seer',
+        'ja': '占い師'
+      },
+      'image': 'https://werewolf.world/image/0.1/seer.jpg',
+      'numberOfAgents': 1,
+      'board': [
+        {
+          'boardAgent': {
+            '@id': 'https://werewolf.world/resource/0.1/Walter',
+            'boardAgentId': 1,
+            'boardAgentName': {
+              'en': 'Walter',
+              'ja': 'ヴァルター'
+            },
+            'boardAgentImage': 'https://werewolf.world/image/0.1/Walter.jpg'
+          },
+          'boardPolarity': 'positive',
+          'boardPhase': 'day conversation',
+          'boardDate': 1
+        }
+      ]
+    },
+    {
+      '@id': 'https://werewolf.world/resource/0.1/medium',
+      'roleIsMine': false,
+      'name': {
+        'en': 'Medium',
+        'ja': '霊媒師'
+      },
+      'image': 'https://werewolf.world/image/0.1/medium.jpg',
+      'numberOfAgents': 1,
+      'board': [
+        {
+          'boardAgent': {
+            '@id': 'https://werewolf.world/resource/0.1/Walter',
+            'boardAgentId': 1,
+            'boardAgentName': {
+              'en': 'Walter',
+              'ja': 'ヴァルター'
+            },
+            'boardAgentImage': 'https://werewolf.world/image/0.1/Walter.jpg'
+          },
+          'boardPolarity': 'negative',
+          'boardPhase': 'day conversation',
+          'boardDate': 1
+        }
+      ]
+    }
+  ]
+
+  expect(getMyRole(roles)).toEqual({
+    '@id': 'https://werewolf.world/resource/0.1/seer',
+    'roleIsMine': true,
+    'name': {
+      'en': 'Seer',
+      'ja': '占い師'
+    },
+    'image': 'https://werewolf.world/image/0.1/seer.jpg',
+    'numberOfAgents': 1,
+    'board': [
+      {
+        'boardAgent': {
+          '@id': 'https://werewolf.world/resource/0.1/Walter',
+          'boardAgentId': 1,
+          'boardAgentName': {
+            'en': 'Walter',
+            'ja': 'ヴァルター'
+          },
+          'boardAgentImage': 'https://werewolf.world/image/0.1/Walter.jpg'
+        },
+        'boardPolarity': 'positive',
+        'boardPhase': 'day conversation',
+        'boardDate': 1
+      }
+    ]
+  })
+})
 test('getPlayableAgents', () => {
   const agents = [
     {
@@ -92,81 +287,6 @@ test('getPlayableAgents', () => {
       'isAChoice': false
     }
   ])
-})
-test('getMyAgent', () => {
-  const agents = [
-    {
-      '@id': 'https://werewolf.world/resource/0.1/Gert',
-      'agentIsMine': false,
-      'name': {
-        'en': 'Gert',
-        'ja': 'ゲルト'
-      },
-      'image': 'https://werewolf.world/image/0.1/Gert.jpg',
-      'id': 0,
-      'status': 'alive',
-      'statusUpdatePhase': 'day conversation',
-      'statusUpdateDate': 1,
-      'isAChoice': false
-    },
-    {
-      '@id': 'https://werewolf.world/resource/0.1/Walter',
-      'agentIsMine': true,
-      'name': {
-        'en': 'Walter',
-        'ja': 'ヴァルター'
-      },
-      'image': 'https://werewolf.world/image/0.1/Walter.jpg',
-      'id': 1,
-      'status': 'alive',
-      'statusUpdatePhase': 'day conversation',
-      'statusUpdateDate': 1,
-      'isAChoice': false
-    },
-    {
-      '@id': 'https://werewolf.world/resource/0.1/Catalina',
-      'agentIsMine': false,
-      'name': {
-        'en': 'Catalina',
-        'ja': 'カタリナ'
-      },
-      'image': 'https://werewolf.world/image/0.1/Catalina.jpg',
-      'id': 10,
-      'status': 'alive',
-      'statusUpdatePhase': 'day conversation',
-      'statusUpdateDate': 1,
-      'isAChoice': false
-    },
-    {
-      '@id': 'https://werewolf.world/resource/0.1/Otto',
-      'agentIsMine': false,
-      'name': {
-        'en': 'Otto',
-        'ja': 'オットー'
-      },
-      'image': 'https://werewolf.world/image/0.1/Otto.jpg',
-      'id': 11,
-      'status': 'alive',
-      'statusUpdatePhase': 'day conversation',
-      'statusUpdateDate': 1,
-      'isAChoice': false
-    }
-  ]
-
-  expect(getMyAgent(agents)).toEqual({
-    '@id': 'https://werewolf.world/resource/0.1/Walter',
-    'agentIsMine': true,
-    'name': {
-      'en': 'Walter',
-      'ja': 'ヴァルター'
-    },
-    'image': 'https://werewolf.world/image/0.1/Walter.jpg',
-    'id': 1,
-    'status': 'alive',
-    'statusUpdatePhase': 'day conversation',
-    'statusUpdateDate': 1,
-    'isAChoice': false
-  })
 })
 test('getPlayableRoles', () => {
   const roles = [
@@ -342,125 +462,12 @@ test('getPlayableRoles', () => {
     }
   ])
 })
-test('getMyRole', () => {
-  const roles = [
-    {
-      '@id': 'https://werewolf.world/resource/0.1/master',
-      'roleIsMine': false,
-      'name': {
-        'en': 'Master',
-        'ja': 'マスター'
-      },
-      'image': 'https://werewolf.world/image/0.1/master.jpg',
-      'numberOfAgents': 1,
-      'board': []
-    },
-    {
-      '@id': 'https://werewolf.world/resource/0.1/villager',
-      'roleIsMine': false,
-      'name': {
-        'en': 'Villager',
-        'ja': '村人'
-      },
-      'image': 'https://werewolf.world/image/0.1/villager.jpg',
-      'numberOfAgents': 6,
-      'board': [
-        {
-          'boardAgent': {
-            '@id': 'https://werewolf.world/resource/0.1/Walter',
-            'boardAgentId': 1,
-            'boardAgentName': {
-              'en': 'Walter',
-              'ja': 'ヴァルター'
-            },
-            'boardAgentImage': 'https://werewolf.world/image/0.1/Walter.jpg'
-          },
-          'boardPolarity': 'negative',
-          'boardPhase': 'day conversation',
-          'boardDate': 1
-        }
-      ]
-    },
-    {
-      '@id': 'https://werewolf.world/resource/0.1/seer',
-      'roleIsMine': true,
-      'name': {
-        'en': 'Seer',
-        'ja': '占い師'
-      },
-      'image': 'https://werewolf.world/image/0.1/seer.jpg',
-      'numberOfAgents': 1,
-      'board': [
-        {
-          'boardAgent': {
-            '@id': 'https://werewolf.world/resource/0.1/Walter',
-            'boardAgentId': 1,
-            'boardAgentName': {
-              'en': 'Walter',
-              'ja': 'ヴァルター'
-            },
-            'boardAgentImage': 'https://werewolf.world/image/0.1/Walter.jpg'
-          },
-          'boardPolarity': 'positive',
-          'boardPhase': 'day conversation',
-          'boardDate': 1
-        }
-      ]
-    },
-    {
-      '@id': 'https://werewolf.world/resource/0.1/medium',
-      'roleIsMine': false,
-      'name': {
-        'en': 'Medium',
-        'ja': '霊媒師'
-      },
-      'image': 'https://werewolf.world/image/0.1/medium.jpg',
-      'numberOfAgents': 1,
-      'board': [
-        {
-          'boardAgent': {
-            '@id': 'https://werewolf.world/resource/0.1/Walter',
-            'boardAgentId': 1,
-            'boardAgentName': {
-              'en': 'Walter',
-              'ja': 'ヴァルター'
-            },
-            'boardAgentImage': 'https://werewolf.world/image/0.1/Walter.jpg'
-          },
-          'boardPolarity': 'negative',
-          'boardPhase': 'day conversation',
-          'boardDate': 1
-        }
-      ]
-    }
-  ]
+test('idGenerater', () => {
+  const generateId = idGenerater('id')
 
-  expect(getMyRole(roles)).toEqual({
-    '@id': 'https://werewolf.world/resource/0.1/seer',
-    'roleIsMine': true,
-    'name': {
-      'en': 'Seer',
-      'ja': '占い師'
-    },
-    'image': 'https://werewolf.world/image/0.1/seer.jpg',
-    'numberOfAgents': 1,
-    'board': [
-      {
-        'boardAgent': {
-          '@id': 'https://werewolf.world/resource/0.1/Walter',
-          'boardAgentId': 1,
-          'boardAgentName': {
-            'en': 'Walter',
-            'ja': 'ヴァルター'
-          },
-          'boardAgentImage': 'https://werewolf.world/image/0.1/Walter.jpg'
-        },
-        'boardPolarity': 'positive',
-        'boardPhase': 'day conversation',
-        'boardDate': 1
-      }
-    ]
-  })
+  expect(generateId()).toBe('id0')
+  expect(generateId()).toBe('id1')
+  expect(generateId()).toBe('id2')
 })
 test('trimBaseUri', () => {
   expect(trimBaseUri('https://werewolf.world/resource/target')).toBe('target')

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -536,7 +536,7 @@ body {
   position: fixed;
   top: 38vh;
   width: 40vw;
-  z-index: 2;
+  z-index: 4;
 
   &--icon {
     align-items: center;
@@ -594,7 +594,7 @@ body {
   position: fixed;
   top: 10vh;
   width: 80vw;
-  z-index: 2;
+  z-index: 4;
 
   &--cell {
     border: 1px solid black;
@@ -687,5 +687,5 @@ body {
   position: fixed;
   top: 0;
   width: 100vw;
-  z-index: 1;
+  z-index: 3;
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -587,8 +587,7 @@ body {
   background: white;
   border: 1px solid black;
   display: grid;
-  grid-template-areas: 'summary summary summary summary summary summary summary';
-  grid-template-columns: calc(var(--result-image-size) + 1rem) 2fr 2fr 1fr calc(var(--result-image-size) + 1rem) calc(var(--result-image-size) + 1rem) 2fr;
+  grid-template-columns: calc(var(--result-image-size) + 1rem) 2fr 2fr calc(var(--result-image-size) + 1rem) calc(4px + var(--result-image-size) + 1rem) 2fr;
   height: 80vh;
   left: 10vw;
   overflow: scroll;
@@ -608,7 +607,16 @@ body {
     text-align: center;
 
     &[ data-result = 'summary' ] {
-      grid-area: summary;
+      grid-column: 1 / 7;
+    }
+
+    &[ data-result = 'caption' ] {
+      grid-column: 1 / 7;
+      padding-top: 2rem;
+    }
+
+    &[ data-result = 'userAvatar' ] {
+      border-left: 4px double black;
     }
 
     &[ data-result = 'image' ],
@@ -618,31 +626,31 @@ body {
       display: inline-flex;
     }
 
-    &[ data-result = 'roleImage' ][ data-tooltip ] {
-      position: relative;
+    &[ data-result = 'roleImage' ] {
+      border-right: none;
 
-      &:hover::after {
-        align-items: center;
-        background: white;
-        border: solid 1px black;
-        bottom: 15%;
-        content: attr(data-tooltip);
-        display: inline-flex;
-        font-size: 10px;
-        justify-content: center;
-        left: 10%;
-        position: absolute;
-        right: 10%;
-        top: 15%;
+      &[ data-tooltip ] {
+        position: relative;
+
+        &:hover::after {
+          align-items: center;
+          background: white;
+          border: solid 1px black;
+          bottom: 15%;
+          content: attr(data-tooltip);
+          display: inline-flex;
+          font-size: 10px;
+          justify-content: center;
+          left: 10%;
+          position: absolute;
+          right: 10%;
+          top: 15%;
+        }
       }
     }
 
     &.dead {
       color: var(--dead-color);
-    }
-
-    &.win {
-      background: var(--win-color);
     }
   }
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -459,8 +459,8 @@ body {
   }
 
   &--select {
-    line-height: 1.5;
     height: 100%;
+    line-height: 1.5;
     width: 100%;
   }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -653,6 +653,31 @@ body {
       color: var(--dead-color);
     }
   }
+
+  &--close {
+    align-items: center;
+    display: inline-flex;
+    filter: opacity(75%);
+    height: 1.5rem;
+    justify-content: center;
+    position: fixed;
+    right: 10vw;
+    top: 10vh;
+    width: 1.5rem;
+
+    & > svg {
+      height: 100%;
+      width: 100%;
+    }
+
+    &:hover {
+      filter: opacity(100%);
+    }
+
+    &:active {
+      filter: opacity(50%);
+    }
+  }
 }
 
 .obfucator {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -585,7 +585,8 @@ body {
 
 .result {
   background: white;
-  border: 1px solid black;
+  border: 2px solid black;
+  border-radius: 8px;
   display: grid;
   grid-template-columns: calc(var(--result-image-size) + 1rem) 2fr 2fr calc(var(--result-image-size) + 1rem) calc(4px + var(--result-image-size) + 1rem) 2fr;
   height: 80vh;

--- a/stories/Result.stories.js
+++ b/stories/Result.stories.js
@@ -162,6 +162,11 @@ storiesOf('village/Result', module)
       'agent6'
     ]
     const me = 'agent0'
+    const summary = {
+      description: '人間側の勝利のため，あなたは勝ちました',
+      loser: '敗者（人狼チーム）',
+      winner: '勝者（人間チーム）'
+    }
     const winners = [
       'agent0',
       'agent2',
@@ -179,7 +184,7 @@ storiesOf('village/Result', module)
         handleClickCloseButton={action('handleCloseClick')}
         losers={losers}
         me={me}
-        summary="summary"
+        summary={summary}
         visible
         winners={winners}
       />
@@ -249,6 +254,11 @@ storiesOf('village/Result', module)
       'agent4'
     ]
     const me = 'agent0'
+    const summary = {
+      description: '人間側の勝利のため，あなたは勝ちました',
+      loser: '敗者（人狼チーム）',
+      winner: '勝者（人間チーム）'
+    }
     const winners = [
       'agent0',
       'agent2',
@@ -260,7 +270,7 @@ storiesOf('village/Result', module)
         handleClickCloseButton={action('handleCloseClick')}
         losers={losers}
         me={me}
-        summary="summary"
+        summary={summary}
         visible
         winners={winners}
       />

--- a/stories/Result.stories.js
+++ b/stories/Result.stories.js
@@ -104,7 +104,7 @@ storiesOf('village/Result', module)
         'agentImage': 'https://werewolf.world/image/0.1/Alvin.jpg',
         'agentName': 'アルビン',
         'roleImage': 'https://werewolf.world/image/0.1/villager.jpg',
-        'roleName':  '村人',
+        'roleName': '村人',
         'status': 'unnatural death',
         'result': 'win',
         'userAvatar': 'https://werewolf.world/image/0.1/Peter.jpg',

--- a/stories/Result.stories.js
+++ b/stories/Result.stories.js
@@ -1,0 +1,186 @@
+// @flow
+/* eslint sort-keys: 0 */
+import React from 'react'
+import Result from '../src/scripts/village/components/Result'
+import {storiesOf} from '@storybook/react'
+import {withInfo} from '@storybook/addon-info'
+import {withKnobs} from '@storybook/addon-knobs/react'
+
+storiesOf('village/Result', module)
+  .addDecorator(withKnobs)
+  .add('default', withInfo('')(() => {
+    const agents = {
+      'agent0': {
+        'agentId': 1,
+        'agentImage': 'https://werewolf.world/image/0.1/Walter.jpg',
+        'agentName': 'ヴァルター',
+        'result': 'win',
+        'roleImage': 'https://werewolf.world/image/0.1/seer.jpg',
+        'roleName': '占い師',
+        'status': 'alive',
+        'userAvatar': 'https://werewolf.world/image/0.1/Gert.jpg',
+        'userName': 'Suzuki'
+      },
+      'agent1': {
+        'agentId': 2,
+        'agentImage': 'https://werewolf.world/image/0.1/Moritz.jpg',
+        'agentName': 'モーリッツ',
+        'result': 'lose',
+        'roleImage': 'https://werewolf.world/image/0.1/werewolf.jpg',
+        'roleName': '人狼',
+        'status': 'alive',
+        'userAvatar': 'https://werewolf.world/image/0.1/Alvin.jpg',
+        'userName': 'Takahashi'
+      },
+      'agent2': {
+        'agentId': 3,
+        'agentImage': 'https://werewolf.world/image/0.1/Simson.jpg',
+        'agentName': 'ジムゾン',
+        'result': 'win',
+        'roleImage': 'https://werewolf.world/image/0.1/hunter.jpg',
+        'roleName': '狩人',
+        'status': 'alive',
+        'userAvatar': 'https://werewolf.world/image/0.1/Friedel.jpg',
+        'userName': 'Tanaka'
+      },
+      'agent3': {
+        'agentId': 4,
+        'agentImage': 'https://werewolf.world/image/0.1/Thomas.jpg',
+        'agentName': 'トーマス',
+        'result': 'win',
+        'roleImage': 'https://werewolf.world/image/0.1/medium.jpg',
+        'roleName': '霊媒師',
+        'status': 'alive',
+        'userAvatar': 'https://werewolf.world/image/0.1/Dieter.jpg',
+        'userName': 'Ito'
+      },
+      'agent4': {
+        'agentId': 5,
+        'agentImage': 'https://werewolf.world/image/0.1/Nicholas.jpg',
+        'agentName': 'ニコラス',
+        'result': 'lose',
+        'roleImage': 'https://werewolf.world/image/0.1/werehumster.jpg',
+        'roleName': 'ハムスター人間',
+        'status': 'death by fear',
+        'userName': 'Watanabe',
+        'userAvatar': 'https://werewolf.world/image/0.1/Erna.jpg'
+      },
+      'agent5': {
+        'agentId': 6,
+        'agentImage': 'https://werewolf.world/image/0.1/Dieter.jpg',
+        'agentName': 'ディーター',
+        'result': 'lose',
+        'roleImage': 'https://werewolf.world/image/0.1/madman.jpg',
+        'roleName': '狂人',
+        'status': 'death by execution',
+        'userName': 'Yamamoto',
+        'userAvatar': 'https://werewolf.world/image/0.1/Jacob.jpg'
+      },
+      'agent6': {
+        'agentId': 7,
+        'agentImage': 'https://werewolf.world/image/0.1/Peter.jpg',
+        'agentName': 'ペーター',
+        'result': 'lose',
+        'roleImage': 'https://werewolf.world/image/0.1/werewolf.jpg',
+        'roleName': '人狼',
+        'status': 'unnatural death',
+        'userName': 'Nakamura',
+        'userAvatar': 'https://werewolf.world/image/0.1/Nicholas.jpg'
+      },
+      'agent7': {
+        'agentImage': 'https://werewolf.world/image/0.1/Lisa.jpg',
+        'agentName': 'リーザ',
+        'agentId': 8,
+        'result': 'win',
+        'roleImage': 'https://werewolf.world/image/0.1/villager.jpg',
+        'roleName': '村人',
+        'status': 'unnatural death',
+        'userAvatar': 'https://werewolf.world/image/0.1/Peter.jpg',
+        'userName': 'Kobayashi'
+      },
+      'agent8': {
+        'agentId': 9,
+        'agentImage': 'https://werewolf.world/image/0.1/Alvin.jpg',
+        'agentName': 'アルビン',
+        'roleImage': 'https://werewolf.world/image/0.1/villager.jpg',
+        'roleName':  '村人',
+        'status': 'unnatural death',
+        'result': 'win',
+        'userAvatar': 'https://werewolf.world/image/0.1/Peter.jpg',
+        'userName': 'Yoshida'
+      },
+      'agent9': {
+        'agentId': 11,
+        'agentImage': 'https://werewolf.world/image/0.1/Otto.jpg',
+        'agentName': 'オットー',
+        'result': 'win',
+        'roleImage': 'https://werewolf.world/image/0.1/mason.jpg',
+        'roleName': '共有者',
+        'status': 'unnatural death',
+        'userAvatar': 'https://werewolf.world/image/0.1/Simson.jpg',
+        'userName': 'Sasaki'
+      },
+      'agent10': {
+        'agentId': 12,
+        'agentImage': 'https://werewolf.world/image/0.1/Joachim.jpg',
+        'agentName': 'ヨアヒム',
+        'result': 'win',
+        'roleImage': 'https://werewolf.world/image/0.1/villager.jpg',
+        'roleName': '村人',
+        'status': 'death by werewolf attack',
+        'userAvatar': 'https://werewolf.world/image/0.1/Otto.jpg',
+        'userName': '山口'
+      },
+      'agent11': {
+        'agentName': 'パメラ',
+        'agentImage': 'https://werewolf.world/image/0.1/Pamela.jpg',
+        'agentId': 13,
+        'result': 'win',
+        'roleImage': 'https://werewolf.world/image/0.1/villager.jpg',
+        'roleName': '村人',
+        'status': 'alive',
+        'userAvatar': 'https://werewolf.world/image/0.1/Joachim.jpg',
+        'userName': '松本'
+      },
+      'agent12': {
+        'agentId': 14,
+        'agentImage': 'https://werewolf.world/image/0.1/Jacob.jpg',
+        'agentName': 'ヤコブ',
+        'result': 'win',
+        'roleImage': 'https://werewolf.world/image/0.1/villager.jpg',
+        'roleName': '村人',
+        'status': 'alive',
+        'userAvatar': 'https://werewolf.world/image/0.1/Catalina.jpg',
+        'userName': '井上'
+      }
+    }
+    const losers = [
+      'agent1',
+      'agent4',
+      'agent5',
+      'agent6'
+    ]
+    const me = 'agent0'
+    const winners = [
+      'agent0',
+      'agent2',
+      'agent3',
+      'agent7',
+      'agent8',
+      'agent9',
+      'agent10',
+      'agent11',
+      'agent12'
+    ]
+    const story =
+      <Result
+        agents={agents}
+        losers={losers}
+        me={me}
+        summary="summary"
+        visible
+        winners={winners}
+      />
+
+    return story
+  }))

--- a/stories/Result.stories.js
+++ b/stories/Result.stories.js
@@ -9,7 +9,7 @@ import {withKnobs} from '@storybook/addon-knobs/react'
 
 storiesOf('village/Result', module)
   .addDecorator(withKnobs)
-  .add('default', withInfo('')(() => {
+  .add('13 players', withInfo('')(() => {
     const agents = {
       'agent0': {
         'agentId': 1,
@@ -172,6 +172,87 @@ storiesOf('village/Result', module)
       'agent10',
       'agent11',
       'agent12'
+    ]
+    const story =
+      <Result
+        agents={agents}
+        handleClickCloseButton={action('handleCloseClick')}
+        losers={losers}
+        me={me}
+        summary="summary"
+        visible
+        winners={winners}
+      />
+
+    return story
+  }))
+  .add('5 players', withInfo('')(() => {
+    const agents = {
+      'agent0': {
+        'agentId': 1,
+        'agentImage': 'https://werewolf.world/image/0.1/Walter.jpg',
+        'agentName': 'ヴァルター',
+        'result': 'win',
+        'roleImage': 'https://werewolf.world/image/0.1/seer.jpg',
+        'roleName': '占い師',
+        'status': 'alive',
+        'userAvatar': 'https://werewolf.world/image/0.1/Gert.jpg',
+        'userName': 'Suzuki'
+      },
+      'agent1': {
+        'agentId': 2,
+        'agentImage': 'https://werewolf.world/image/0.1/Moritz.jpg',
+        'agentName': 'モーリッツ',
+        'result': 'lose',
+        'roleImage': 'https://werewolf.world/image/0.1/werewolf.jpg',
+        'roleName': '人狼',
+        'status': 'alive',
+        'userAvatar': 'https://werewolf.world/image/0.1/Alvin.jpg',
+        'userName': 'Takahashi'
+      },
+      'agent2': {
+        'agentId': 3,
+        'agentImage': 'https://werewolf.world/image/0.1/Simson.jpg',
+        'agentName': 'ジムゾン',
+        'result': 'win',
+        'roleImage': 'https://werewolf.world/image/0.1/hunter.jpg',
+        'roleName': '狩人',
+        'status': 'alive',
+        'userAvatar': 'https://werewolf.world/image/0.1/Friedel.jpg',
+        'userName': 'Tanaka'
+      },
+      'agent3': {
+        'agentId': 4,
+        'agentImage': 'https://werewolf.world/image/0.1/Thomas.jpg',
+        'agentName': 'トーマス',
+        'result': 'win',
+        'roleImage': 'https://werewolf.world/image/0.1/medium.jpg',
+        'roleName': '霊媒師',
+        'status': 'alive',
+        'userAvatar': 'https://werewolf.world/image/0.1/Dieter.jpg',
+        'userName': 'Ito'
+      },
+      'agent4': {
+        'agentId': 5,
+        'agentImage': 'https://werewolf.world/image/0.1/Nicholas.jpg',
+        'agentName': 'ニコラス',
+        'result': 'lose',
+        'roleImage': 'https://werewolf.world/image/0.1/werehumster.jpg',
+        'roleName': 'ハムスター人間',
+        'status': 'death by fear',
+        'userName': 'Watanabe',
+        'userAvatar': 'https://werewolf.world/image/0.1/Erna.jpg'
+      }
+    }
+    const losers = [
+      'agent1',
+      'agent4'
+    ]
+    const me = 'agent0'
+    const winners = [
+      'agent0',
+      'agent2',
+      'agent3'
     ]
     const story =
       <Result

--- a/stories/Result.stories.js
+++ b/stories/Result.stories.js
@@ -2,6 +2,7 @@
 /* eslint sort-keys: 0 */
 import React from 'react'
 import Result from '../src/scripts/village/components/Result'
+import {action} from '@storybook/addon-actions'
 import {storiesOf} from '@storybook/react'
 import {withInfo} from '@storybook/addon-info'
 import {withKnobs} from '@storybook/addon-knobs/react'
@@ -175,6 +176,7 @@ storiesOf('village/Result', module)
     const story =
       <Result
         agents={agents}
+        handleClickCloseButton={action('handleCloseClick')}
         losers={losers}
         me={me}
         summary="summary"

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -150,7 +150,7 @@ module.exports = {
     'unit-case': 'lower',
     'unit-no-unknown': true,
     'unit-whitelist': [
-      [ 'rem', '%', 's', 'vh', 'vw' ], {
+      [ 'fr', 'px', 'rem', 'vh', 'vw', '%' ], {
         'severity': 'warning'
       }
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,29 +2,29 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.40", "@babel/code-frame@^7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz#37e2b0cf7c56026b4b21d3927cadf81adec32ac6"
+"@babel/code-frame@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
   dependencies:
-    "@babel/highlight" "7.0.0-beta.40"
+    "@babel/highlight" "7.0.0-beta.44"
 
-"@babel/code-frame@7.0.0-beta.42", "@babel/code-frame@^7.0.0-beta.35":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.42.tgz#a9c83233fa7cd06b39dc77adbb908616ff4f1962"
+"@babel/code-frame@7.0.0-beta.46", "@babel/code-frame@^7.0.0-beta.35":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz#e0d002100805daab1461c0fcb32a07e304f3a4f4"
   dependencies:
-    "@babel/highlight" "7.0.0-beta.42"
+    "@babel/highlight" "7.0.0-beta.46"
 
 "@babel/core@^7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.42.tgz#b3a838fddbd19663369a0b4892189fd8d3f82001"
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.46.tgz#dbe2189bcdef9a2c84becb1ec624878d31a95689"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.42"
-    "@babel/generator" "7.0.0-beta.42"
-    "@babel/helpers" "7.0.0-beta.42"
-    "@babel/template" "7.0.0-beta.42"
-    "@babel/traverse" "7.0.0-beta.42"
-    "@babel/types" "7.0.0-beta.42"
-    babylon "7.0.0-beta.42"
+    "@babel/code-frame" "7.0.0-beta.46"
+    "@babel/generator" "7.0.0-beta.46"
+    "@babel/helpers" "7.0.0-beta.46"
+    "@babel/template" "7.0.0-beta.46"
+    "@babel/traverse" "7.0.0-beta.46"
+    "@babel/types" "7.0.0-beta.46"
+    babylon "7.0.0-beta.46"
     convert-source-map "^1.1.0"
     debug "^3.1.0"
     json5 "^0.5.0"
@@ -34,142 +34,149 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.40.tgz#ab61f9556f4f71dbd1138949c795bb9a21e302ea"
+"@babel/generator@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.44.tgz#c7e67b9b5284afcf69b309b50d7d37f3e5033d42"
   dependencies:
-    "@babel/types" "7.0.0-beta.40"
+    "@babel/types" "7.0.0-beta.44"
     jsesc "^2.5.1"
     lodash "^4.2.0"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/generator@7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.42.tgz#777bb50f39c94a7e57f73202d833141f8159af33"
+"@babel/generator@7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.46.tgz#6f57159bcc28bf8c3ed6b549789355cebfa3faa7"
   dependencies:
-    "@babel/types" "7.0.0-beta.42"
+    "@babel/types" "7.0.0-beta.46"
     jsesc "^2.5.1"
     lodash "^4.2.0"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/helper-function-name@7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz#9d033341ab16517f40d43a73f2d81fc431ccd7b6"
+"@babel/helper-function-name@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz#e18552aaae2231100a6e485e03854bc3532d44dd"
   dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.40"
-    "@babel/template" "7.0.0-beta.40"
-    "@babel/types" "7.0.0-beta.40"
+    "@babel/helper-get-function-arity" "7.0.0-beta.44"
+    "@babel/template" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-function-name@7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.42.tgz#b38b8f4f85168d1812c543dd700b5d549b0c4658"
+"@babel/helper-function-name@7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.46.tgz#d0c4eed2e220e180f91b02e008dcc4594afe1d39"
   dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.42"
-    "@babel/template" "7.0.0-beta.42"
-    "@babel/types" "7.0.0-beta.42"
+    "@babel/helper-get-function-arity" "7.0.0-beta.46"
+    "@babel/template" "7.0.0-beta.46"
+    "@babel/types" "7.0.0-beta.46"
 
-"@babel/helper-get-function-arity@7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz#ac0419cf067b0ec16453e1274f03878195791c6e"
+"@babel/helper-get-function-arity@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz#d03ca6dd2b9f7b0b1e6b32c56c72836140db3a15"
   dependencies:
-    "@babel/types" "7.0.0-beta.40"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-get-function-arity@7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.42.tgz#ad072e32f912c033053fc80478169aeadc22191e"
+"@babel/helper-get-function-arity@7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.46.tgz#7161bfe449b4183dbe25d1fe5579338b7429e5f2"
   dependencies:
-    "@babel/types" "7.0.0-beta.42"
+    "@babel/types" "7.0.0-beta.46"
 
-"@babel/helper-split-export-declaration@7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.42.tgz#0d0d5254220a9cc4e7e226240306b939dc210ee7"
+"@babel/helper-split-export-declaration@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz#c0b351735e0fbcb3822c8ad8db4e583b05ebd9dc"
   dependencies:
-    "@babel/types" "7.0.0-beta.42"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helpers@7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.0.0-beta.42.tgz#151c1c4e9da1b6ce83d54c1be5fb8c9c57aa5044"
+"@babel/helper-split-export-declaration@7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.46.tgz#6903893c72bb2a3d54ed20b5ff2aa8a28e8d2ea1"
   dependencies:
-    "@babel/template" "7.0.0-beta.42"
-    "@babel/traverse" "7.0.0-beta.42"
-    "@babel/types" "7.0.0-beta.42"
+    "@babel/types" "7.0.0-beta.46"
 
-"@babel/highlight@7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.40.tgz#b43d67d76bf46e1d10d227f68cddcd263786b255"
+"@babel/helpers@7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.0.0-beta.46.tgz#b5f988dfd77f4f713792cf7818b687050736ee52"
+  dependencies:
+    "@babel/template" "7.0.0-beta.46"
+    "@babel/traverse" "7.0.0-beta.46"
+    "@babel/types" "7.0.0-beta.46"
+
+"@babel/highlight@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.44.tgz#18c94ce543916a80553edcdcf681890b200747d5"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/highlight@7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.42.tgz#a502a1c0d6f99b2b0e81d468a1b0c0e81e3f3623"
+"@babel/highlight@7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.46.tgz#c553c51e65f572bdedd6eff66fc0bb563016645e"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/template@7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.40.tgz#034988c6424eb5c3268fe6a608626de1f4410fc8"
+"@babel/template@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.40"
-    "@babel/types" "7.0.0-beta.40"
-    babylon "7.0.0-beta.40"
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
     lodash "^4.2.0"
 
-"@babel/template@7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.42.tgz#7186d4e70d44cdec975049ba0a73bdaf5cdee052"
+"@babel/template@7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.46.tgz#8b23982411d5b5dbfa479437bfe414adb1411bb9"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.42"
-    "@babel/types" "7.0.0-beta.42"
-    babylon "7.0.0-beta.42"
+    "@babel/code-frame" "7.0.0-beta.46"
+    "@babel/types" "7.0.0-beta.46"
+    babylon "7.0.0-beta.46"
     lodash "^4.2.0"
 
-"@babel/traverse@7.0.0-beta.42", "@babel/traverse@^7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.42.tgz#f4bf4d1e33d41baf45205e2d0463591d57326285"
+"@babel/traverse@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.44.tgz#a970a2c45477ad18017e2e465a0606feee0d2966"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.42"
-    "@babel/generator" "7.0.0-beta.42"
-    "@babel/helper-function-name" "7.0.0-beta.42"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.42"
-    "@babel/types" "7.0.0-beta.42"
-    babylon "7.0.0-beta.42"
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/generator" "7.0.0-beta.44"
+    "@babel/helper-function-name" "7.0.0-beta.44"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
     debug "^3.1.0"
     globals "^11.1.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-"@babel/traverse@^7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.40.tgz#d140e449b2e093ef9fe1a2eecc28421ffb4e521e"
+"@babel/traverse@7.0.0-beta.46", "@babel/traverse@^7.0.0-beta.42":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.46.tgz#29a0c0395b3642f0297e6f8e475bde89f9343755"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.40"
-    "@babel/generator" "7.0.0-beta.40"
-    "@babel/helper-function-name" "7.0.0-beta.40"
-    "@babel/types" "7.0.0-beta.40"
-    babylon "7.0.0-beta.40"
-    debug "^3.0.1"
+    "@babel/code-frame" "7.0.0-beta.46"
+    "@babel/generator" "7.0.0-beta.46"
+    "@babel/helper-function-name" "7.0.0-beta.46"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.46"
+    "@babel/types" "7.0.0-beta.46"
+    babylon "7.0.0-beta.46"
+    debug "^3.1.0"
     globals "^11.1.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-"@babel/types@7.0.0-beta.40", "@babel/types@^7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.40.tgz#25c3d7aae14126abe05fcb098c65a66b6d6b8c14"
+"@babel/types@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.44.tgz#6b1b164591f77dec0a0342aca995f2d046b3a757"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@babel/types@7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.42.tgz#1e2118767684880f6963801b272fd2b3348efacc"
+"@babel/types@7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.46.tgz#eb84399a699af9fcb244440cce78e1acbeb40e0c"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.2.0"
@@ -182,11 +189,11 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@storybook/addon-actions@3.4.0", "@storybook/addon-actions@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.4.0.tgz#8f6f869f708856845dff210af9340e54b443f346"
+"@storybook/addon-actions@3.4.3", "@storybook/addon-actions@^3.4.0":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.4.3.tgz#27ac798cb0085c9588c4fd0a1c4cbfa32ce3bd54"
   dependencies:
-    "@storybook/components" "3.4.0"
+    "@storybook/components" "3.4.3"
     babel-runtime "^6.26.0"
     deep-equal "^1.0.1"
     glamor "^2.20.40"
@@ -198,11 +205,11 @@
     uuid "^3.2.1"
 
 "@storybook/addon-info@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-info/-/addon-info-3.4.0.tgz#26cb866c596208721642c7635fc87909f89c809c"
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-info/-/addon-info-3.4.3.tgz#c47d4ffef43e3662d3b0d54f400716ff9907dcfd"
   dependencies:
-    "@storybook/client-logger" "3.4.0"
-    "@storybook/components" "3.4.0"
+    "@storybook/client-logger" "3.4.3"
+    "@storybook/components" "3.4.3"
     babel-runtime "^6.26.0"
     glamor "^2.20.40"
     glamorous "^4.12.1"
@@ -214,10 +221,10 @@
     util-deprecate "^1.0.2"
 
 "@storybook/addon-knobs@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-3.4.0.tgz#2542f2871ec53f5db5a683a0fbbd06fc455c0f4b"
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-3.4.3.tgz#0d002c3519470787d1dd355106ccf391e462b3cb"
   dependencies:
-    "@storybook/components" "3.4.0"
+    "@storybook/components" "3.4.3"
     babel-runtime "^6.26.0"
     deep-equal "^1.0.1"
     global "^4.3.2"
@@ -230,36 +237,36 @@
     react-textarea-autosize "^5.2.1"
     util-deprecate "^1.0.2"
 
-"@storybook/addon-links@3.4.0", "@storybook/addon-links@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.4.0.tgz#638218a567b9318a72ab268963d7efcd47878164"
+"@storybook/addon-links@3.4.3", "@storybook/addon-links@^3.4.0":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.4.3.tgz#93bb28e10830b1b230be8b1710265d5d06453bde"
   dependencies:
-    "@storybook/components" "3.4.0"
+    "@storybook/components" "3.4.3"
     babel-runtime "^6.26.0"
     global "^4.3.2"
     prop-types "^15.6.1"
 
-"@storybook/addons@3.4.0", "@storybook/addons@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.4.0.tgz#c1a96d32759df0117b7b9e50e33ff6c7f98b34c9"
+"@storybook/addons@3.4.3", "@storybook/addons@^3.4.0":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.4.3.tgz#537311d621cb3d582d581a160813608d6b27e4bd"
 
-"@storybook/channel-postmessage@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-3.4.0.tgz#824ef774392e74802b9db368e1f97f2447652a14"
+"@storybook/channel-postmessage@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-3.4.3.tgz#0e9e9860b00d927ddd184e5aaf26d101f5f7ccf6"
   dependencies:
-    "@storybook/channels" "3.4.0"
+    "@storybook/channels" "3.4.3"
     global "^4.3.2"
     json-stringify-safe "^5.0.1"
 
-"@storybook/channels@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.4.0.tgz#0702b8ddfee16aa69da942e18628e563fa7e1be0"
+"@storybook/channels@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.4.3.tgz#045fc72787b38dd71210b5fb20c9daa739a2f601"
 
 "@storybook/cli@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-3.4.0.tgz#6f0af91d8e2030cb258e4543a8b0af93869447db"
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-3.4.3.tgz#103dd59d0e47a82d33e8a34919be606a406d8069"
   dependencies:
-    "@storybook/codemod" "3.4.0"
+    "@storybook/codemod" "3.4.3"
     babel-plugin-transform-runtime "^6.23.0"
     babel-preset-env "^1.6.0"
     babel-register "^6.26.0"
@@ -275,33 +282,33 @@
     shelljs "^0.8.1"
     update-notifier "^2.3.0"
 
-"@storybook/client-logger@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-3.4.0.tgz#130b1812cb5b5e9ea6962930da2c17265056defd"
+"@storybook/client-logger@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-3.4.3.tgz#72ea30e23e05a4dc13b3b1970665e40407368ffe"
 
-"@storybook/codemod@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-3.4.0.tgz#4b1f6255334acd6863c105c689b833120fb01fb2"
+"@storybook/codemod@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-3.4.3.tgz#cdea33568fa5338baf7ad08cccca0e6839df8d04"
   dependencies:
     jscodeshift "^0.5.0"
 
-"@storybook/components@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.4.0.tgz#b9cb9aee02b9ff9311433d8b57c60d0350b21880"
+"@storybook/components@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.4.3.tgz#d21a9eb63c61529cfbb802d96ceaa67fb7fd50b0"
   dependencies:
     glamor "^2.20.40"
     glamorous "^4.12.1"
     prop-types "^15.6.1"
 
-"@storybook/core@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-3.4.0.tgz#7f0135047682e56503f5509cb2bd2dc6b27c0ca4"
+"@storybook/core@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-3.4.3.tgz#40375ad652e3b22e2c3373e05cb9cff0456f3865"
   dependencies:
-    "@storybook/addons" "3.4.0"
-    "@storybook/channel-postmessage" "3.4.0"
-    "@storybook/client-logger" "3.4.0"
-    "@storybook/node-logger" "3.4.0"
-    "@storybook/ui" "3.4.0"
+    "@storybook/addons" "3.4.3"
+    "@storybook/channel-postmessage" "3.4.3"
+    "@storybook/client-logger" "3.4.3"
+    "@storybook/node-logger" "3.4.3"
+    "@storybook/ui" "3.4.3"
     autoprefixer "^7.2.6"
     babel-runtime "^6.26.0"
     chalk "^2.3.2"
@@ -317,15 +324,13 @@
     postcss-loader "^2.1.2"
     prop-types "^15.6.1"
     qs "^6.5.1"
-    react "^16.0.0"
-    react-dom "^16.0.0"
     serve-favicon "^2.4.5"
     shelljs "^0.8.1"
     style-loader "^0.20.3"
     url-loader "^0.6.2"
     webpack "^3.11.0"
     webpack-dev-middleware "^1.12.2"
-    webpack-hot-middleware "^2.21.2"
+    webpack-hot-middleware "^2.22.1"
 
 "@storybook/mantra-core@^1.7.2":
   version "1.7.2"
@@ -335,9 +340,9 @@
     "@storybook/react-simple-di" "^1.2.1"
     babel-runtime "6.x.x"
 
-"@storybook/node-logger@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-3.4.0.tgz#ca06884967d98403b7524a424e60d7443c0080d1"
+"@storybook/node-logger@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-3.4.3.tgz#d8014cfbaca0e6b5bbeb05f419ba08363c3aa5f6"
   dependencies:
     npmlog "^4.1.2"
 
@@ -374,21 +379,21 @@
     babel-runtime "^6.5.0"
 
 "@storybook/react@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-3.4.0.tgz#7c19d71ce27bb78b2d7a33d4fa2b30eceffe2677"
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-3.4.3.tgz#d5b17921eb0a0910415f8624f145d940456b47f4"
   dependencies:
-    "@storybook/addon-actions" "3.4.0"
-    "@storybook/addon-links" "3.4.0"
-    "@storybook/addons" "3.4.0"
-    "@storybook/channel-postmessage" "3.4.0"
-    "@storybook/client-logger" "3.4.0"
-    "@storybook/core" "3.4.0"
-    "@storybook/node-logger" "3.4.0"
-    "@storybook/ui" "3.4.0"
+    "@storybook/addon-actions" "3.4.3"
+    "@storybook/addon-links" "3.4.3"
+    "@storybook/addons" "3.4.3"
+    "@storybook/channel-postmessage" "3.4.3"
+    "@storybook/client-logger" "3.4.3"
+    "@storybook/core" "3.4.3"
+    "@storybook/node-logger" "3.4.3"
+    "@storybook/ui" "3.4.3"
     airbnb-js-shims "^1.4.1"
     babel-loader "^7.1.4"
     babel-plugin-macros "^2.2.0"
-    babel-plugin-react-docgen "^1.8.3"
+    babel-plugin-react-docgen "^1.9.0"
     babel-plugin-transform-regenerator "^6.26.0"
     babel-plugin-transform-runtime "^6.23.0"
     babel-preset-env "^1.6.1"
@@ -415,7 +420,7 @@
     uglifyjs-webpack-plugin "^1.2.4"
     util-deprecate "^1.0.2"
     webpack "^3.11.0"
-    webpack-hot-middleware "^2.21.2"
+    webpack-hot-middleware "^2.22.1"
 
 "@storybook/storybook-deployer@^2.3.0":
   version "2.3.0"
@@ -426,11 +431,11 @@
     shelljs "^0.8.1"
     yargs "^11.0.0"
 
-"@storybook/ui@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.4.0.tgz#4826b7e5b67c0c6d0515c0aedf8df48f8c2ea3da"
+"@storybook/ui@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.4.3.tgz#8f3f43da32290abab2e4293d2567316b2d2ce91a"
   dependencies:
-    "@storybook/components" "3.4.0"
+    "@storybook/components" "3.4.3"
     "@storybook/mantra-core" "^1.7.2"
     "@storybook/podda" "^1.2.3"
     "@storybook/react-komposer" "^2.0.3"
@@ -453,8 +458,8 @@
     react-treebeard "^2.1.0"
 
 "@types/node@*":
-  version "9.4.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.6.tgz#d8176d864ee48753d053783e4e463aec86b8d82e"
+  version "8.10.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.11.tgz#971ea8cb91adbe0b74e3fbd867dec192d5893a5f"
 
 abab@^1.0.4:
   version "1.0.4"
@@ -533,15 +538,8 @@ ajv-keywords@^2.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
 ajv-keywords@^3.0.0, ajv-keywords@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.1.0.tgz#ac2b27939c543e95d2c06e7f7f5c27be4aa543be"
-
-ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
 ajv@^5.0.0, ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
@@ -700,8 +698,8 @@ array-includes@^3.0.3:
     es-abstract "^1.7.0"
 
 array-iterate@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.1.tgz#865bf7f8af39d6b0982c60902914ac76bc0108f6"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.2.tgz#f66a57e84426f8097f4197fbb6c051b8e5cdf7d8"
 
 array-map@~0.0.0:
   version "0.0.0"
@@ -776,10 +774,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
 
-assert-plus@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
-
 assert@^1.1.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
@@ -829,8 +823,8 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
 atob@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.0.tgz#ab2b150e51d7b122b9efc8d7340c06b6c41076bc"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
 autoprefixer@^6.3.1:
   version "6.7.7"
@@ -855,27 +849,23 @@ autoprefixer@^7.2.6:
     postcss-value-parser "^3.2.3"
 
 autoprefixer@^8.0.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.2.0.tgz#1e49b611b31a5259b86b7a6b2b1b8faf091abe2a"
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.4.1.tgz#c6b30001ea4b3daa6b611e50071f62dd24beb564"
   dependencies:
-    browserslist "^3.2.0"
-    caniuse-lite "^1.0.30000817"
+    browserslist "^3.2.6"
+    caniuse-lite "^1.0.30000832"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^6.0.20"
+    postcss "^6.0.22"
     postcss-value-parser "^3.2.3"
-
-aws-sign2@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
 
-aws4@^1.2.1, aws4@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+aws4@^1.6.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
 babel-code-frame@6.26.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -886,8 +876,8 @@ babel-code-frame@6.26.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     js-tokens "^3.0.2"
 
 babel-core@^6.0.0, babel-core@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   dependencies:
     babel-code-frame "^6.26.0"
     babel-generator "^6.26.0"
@@ -899,24 +889,24 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     babel-traverse "^6.26.0"
     babel-types "^6.26.0"
     babylon "^6.18.0"
-    convert-source-map "^1.5.0"
-    debug "^2.6.8"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
     json5 "^0.5.1"
     lodash "^4.17.4"
     minimatch "^3.0.4"
     path-is-absolute "^1.0.1"
-    private "^0.1.7"
+    private "^0.1.8"
     slash "^1.0.0"
-    source-map "^0.5.6"
+    source-map "^0.5.7"
 
 babel-eslint@^8.0.1:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.2.tgz#1102273354c6f0b29b4ea28a65f97d122296b68b"
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.3.tgz#1a2e6681cc9bc4473c32899e59915e19cd6733cf"
   dependencies:
-    "@babel/code-frame" "^7.0.0-beta.40"
-    "@babel/traverse" "^7.0.0-beta.40"
-    "@babel/types" "^7.0.0-beta.40"
-    babylon "^7.0.0-beta.40"
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/traverse" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
     eslint-scope "~3.7.1"
     eslint-visitor-keys "^1.0.0"
 
@@ -1115,12 +1105,13 @@ babel-plugin-check-es2015-constants@^6.22.0:
     babel-runtime "^6.22.0"
 
 babel-plugin-istanbul@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
   dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
     find-up "^2.1.0"
-    istanbul-lib-instrument "^1.7.5"
-    test-exclude "^4.1.1"
+    istanbul-lib-instrument "^1.10.1"
+    test-exclude "^4.2.1"
 
 babel-plugin-jest-hoist@^22.4.3:
   version "22.4.3"
@@ -1197,7 +1188,7 @@ babel-plugin-minify-type-constructors@^0.3.0:
   dependencies:
     babel-helper-is-void-0 "^0.3.0"
 
-babel-plugin-react-docgen@^1.8.3:
+babel-plugin-react-docgen@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.9.0.tgz#2e79aeed2f93b53a172398f93324fdcf9f02e01f"
   dependencies:
@@ -1396,8 +1387,8 @@ babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015
     babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
+  version "6.26.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
   dependencies:
     babel-plugin-transform-strict-mode "^6.24.1"
     babel-runtime "^6.26.0"
@@ -1513,16 +1504,16 @@ babel-plugin-transform-inline-consecutive-adds@^0.3.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.3.0.tgz#f07d93689c0002ed2b2b62969bdd99f734e03f57"
 
 babel-plugin-transform-member-expression-literals@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.0.tgz#ab07ad52a11ff7d2528c71388e8f901a4499c2b2"
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.1.tgz#96be2e9968e7f5497333ae03284ecd5340405489"
 
 babel-plugin-transform-merge-sibling-variables@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.0.tgz#140017e305f8eb4f60d2f2db61154fbd71a9fcdd"
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.1.tgz#9071e443b21458ce6b0a8d3841ba5a174f5dc282"
 
 babel-plugin-transform-minify-booleans@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.0.tgz#e36ceaa49aadcae70ec98bd9dbccb660719a667a"
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.1.tgz#52cba79c00fa509737064055efab22166e140c4d"
 
 babel-plugin-transform-object-rest-spread@^6.20.2, babel-plugin-transform-object-rest-spread@^6.22.0, babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
@@ -1532,8 +1523,8 @@ babel-plugin-transform-object-rest-spread@^6.20.2, babel-plugin-transform-object
     babel-runtime "^6.26.0"
 
 babel-plugin-transform-property-literals@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.0.tgz#4ddc12ada888927eacab4daff8a535ebc5de5a61"
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.1.tgz#6970f93b17793abcde9cf25d2e8cd13e0088e5c9"
   dependencies:
     esutils "^2.0.2"
 
@@ -1576,12 +1567,12 @@ babel-plugin-transform-regexp-constructors@^0.3.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.3.0.tgz#9bb2c8dd082271a5cb1b3a441a7c52e8fd07e0f5"
 
 babel-plugin-transform-remove-console@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.0.tgz#a7b671aab050dd30ef7cf2142b61a7d10efb327f"
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.1.tgz#40fe95d98cae5811d8a0e1889812d78b12859651"
 
 babel-plugin-transform-remove-debugger@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.0.tgz#b465e74b3fbe1970da561fb1331e30aefac3f1fe"
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.1.tgz#76552d2e9d6c43d9c676bbfc08f3c2a2cc14be14"
 
 babel-plugin-transform-remove-undefined@^0.3.0:
   version "0.3.0"
@@ -1596,8 +1587,8 @@ babel-plugin-transform-runtime@^6.23.0:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-simplify-comparison-operators@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.0.tgz#586252fea023cb13f2400a09c0ab178dc0844f0a"
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.1.tgz#5b0d06980a17a780f5318b274c00be2fb1c7c4fe"
 
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
@@ -1607,8 +1598,8 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-types "^6.24.1"
 
 babel-plugin-transform-undefined-to-void@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.0.tgz#eb5db0554caffe9ded0206468ec0c6c3b332b9d2"
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.1.tgz#d7df9c1dd0ec12e0ffe895ed1445f61f1bf5e221"
 
 babel-polyfill@^6.26.0:
   version "6.26.0"
@@ -1836,21 +1827,17 @@ babylon@7.0.0-beta.31:
   version "7.0.0-beta.31"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
 
-babylon@7.0.0-beta.40, babylon@^7.0.0-beta.40:
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.40.tgz#91fc8cd56d5eb98b28e6fde41045f2957779940a"
+babylon@7.0.0-beta.44:
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
 
-babylon@7.0.0-beta.42, babylon@^7.0.0-beta.42:
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.42.tgz#67cfabcd4f3ec82999d29031ccdea89d0ba99657"
+babylon@7.0.0-beta.46, babylon@^7.0.0-beta.30, babylon@^7.0.0-beta.42:
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.46.tgz#b6ddaba81bbb130313932757ff9c195d527088b6"
 
 babylon@^6.15.0, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-
-babylon@^7.0.0-beta.30:
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
 
 badge-up@2.3.0:
   version "2.3.0"
@@ -1861,8 +1848,8 @@ badge-up@2.3.0:
     svgo "~0.4.5"
 
 bail@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.2.tgz#f7d6c1731630a9f9f0d4d35ed1f962e2074a1764"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.3.tgz#63cfb9ddbac829b02a3128cd53224be78e6c21a3"
 
 balanced-match@^0.4.2:
   version "0.4.2"
@@ -1873,8 +1860,8 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 base64-js@^1.0.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
 
 base@^0.11.1:
   version "0.11.2"
@@ -1895,8 +1882,8 @@ bcrypt-pbkdf@^1.0.0:
     tweetnacl "^0.14.3"
 
 big-integer@^1.6.17:
-  version "1.6.27"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.27.tgz#8e56c6f8b2dd6c4fe8d32102b83d4f25868e4b3a"
+  version "1.6.28"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.28.tgz#8cef0fda3ccde8759c2c66efcfacc35aea658283"
 
 big.js@^3.1.3:
   version "3.2.0"
@@ -1912,12 +1899,6 @@ binary@~0.3.0:
   dependencies:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
-
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  dependencies:
-    inherits "~2.0.0"
 
 bluebird@^3.4.7, bluebird@^3.5.1:
   version "3.5.1"
@@ -1949,12 +1930,6 @@ body-parser@1.18.2:
 boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-
-boom@2.x.x:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
-  dependencies:
-    hoek "2.x.x"
 
 boom@4.x.x:
   version "4.3.1"
@@ -2000,16 +1975,14 @@ braces@^1.8.2:
     repeat-element "^1.1.2"
 
 braces@^2.3.0, braces@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.1.tgz#7086c913b4e5a08dbe37ac0ee6a2500c4ba691bb"
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
   dependencies:
     arr-flatten "^1.1.0"
     array-unique "^0.3.2"
-    define-property "^1.0.0"
     extend-shallow "^2.0.1"
     fill-range "^4.0.0"
     isobject "^3.0.1"
-    kind-of "^6.0.2"
     repeat-element "^1.1.2"
     snapdragon "^0.8.1"
     snapdragon-node "^2.0.1"
@@ -2035,8 +2008,8 @@ browser-resolve@^1.11.2:
     resolve "1.1.7"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.1.1.tgz#38b7ab55edb806ff2dcda1a7f1620773a477c49f"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
   dependencies:
     buffer-xor "^1.0.3"
     cipher-base "^1.0.0"
@@ -2046,16 +2019,16 @@ browserify-aes@^1.0.0, browserify-aes@^1.0.4:
     safe-buffer "^5.0.1"
 
 browserify-cipher@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.0.tgz#9988244874bf5ed4e28da95666dcd66ac8fc363a"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
   dependencies:
     browserify-aes "^1.0.4"
     browserify-des "^1.0.0"
     evp_bytestokey "^1.0.0"
 
 browserify-des@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.0.tgz#daa277717470922ed2fe18594118a175439721dd"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.1.tgz#3343124db6d7ad53e26a8826318712bdc8450f9c"
   dependencies:
     cipher-base "^1.0.1"
     des.js "^1.0.0"
@@ -2100,12 +2073,12 @@ browserslist@^2.1.2, browserslist@^2.11.3:
     caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
 
-browserslist@^3.2.0:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.4.tgz#fb9ad70fd09875137ae943a31ab815ed76896031"
+browserslist@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.6.tgz#138a44d04a9af64443679191d041f28ce5b965d5"
   dependencies:
-    caniuse-lite "^1.0.30000821"
-    electron-to-chromium "^1.3.41"
+    caniuse-lite "^1.0.30000830"
+    electron-to-chromium "^1.3.42"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -2240,20 +2213,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000824"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000824.tgz#bba3ff425296e04caa37fe426259206a7056551b"
+  version "1.0.30000832"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000832.tgz#afe34c9f7c62139fd1c607db2ab7308bbb6a5158"
 
-caniuse-lite@^1.0.30000792:
-  version "1.0.30000810"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz#47585fffce0e9f3593a6feea4673b945424351d9"
-
-caniuse-lite@^1.0.30000805:
-  version "1.0.30000824"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000824.tgz#de3bc1ba0bff4937302f8cb2a8632a8cc1c07f9a"
-
-caniuse-lite@^1.0.30000817, caniuse-lite@^1.0.30000821:
-  version "1.0.30000821"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000821.tgz#0f3223f1e048ed96451c56ca6cf197058c42cb93"
+caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000830, caniuse-lite@^1.0.30000832:
+  version "1.0.30000832"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000832.tgz#22a277f1d623774cc9aea2f7c1a65cb1603c63b8"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -2268,8 +2233,8 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
 ccount@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.2.tgz#53b6a2f815bb77b9c2871f7b9a72c3a25f1d8e89"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -2277,10 +2242,6 @@ center-align@^0.1.1:
   dependencies:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
-
-chain-function@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
 
 chainsaw@~0.1.0:
   version "0.1.0"
@@ -2298,9 +2259,9 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -2315,20 +2276,20 @@ chalk@~0.4.0:
     strip-ansi "~0.1.0"
 
 character-entities-html4@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.1.tgz#359a2a4a0f7e29d3dc2ac99bdbe21ee39438ea50"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.2.tgz#c44fdde3ce66b52e8d321d6c1bf46101f0150610"
 
 character-entities-legacy@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz#f40779df1a101872bb510a3d295e1fccf147202f"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz#7c6defb81648498222c9855309953d05f4d63a9c"
 
 character-entities@^1.0.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.1.tgz#f76871be5ef66ddb7f8f8e3478ecc374c27d6dca"
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.2.tgz#58c8f371c0774ef0ba9b2aca5f00d8f100e6e363"
 
 character-reference-invalid@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz#942835f750e4ec61a308e60c2ef8cc1011202efc"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -2380,8 +2341,8 @@ chownr@^1.0.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
 chrome-trace-event@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-0.1.2.tgz#90f36885d5345a50621332f0717b595883d5d982"
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-0.1.3.tgz#d395af2d31c87b90a716c831fe326f69768ec084"
 
 ci-info@^1.0.0:
   version "1.1.3"
@@ -2464,8 +2425,8 @@ cliui@^3.2.0:
     wrap-ansi "^2.0.0"
 
 cliui@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
@@ -2503,8 +2464,8 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
 collapse-white-space@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.3.tgz#4b906f670e5a963a87b76b0e1689643341b6023c"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.4.tgz#ce05cf49e54c3277ae573036a26851ba430a0091"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -2550,8 +2511,8 @@ colors@0.5.x:
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
 colors@^1.0.3, colors@^1.1.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.1.tgz#f4a3d302976aaf042356ba1ade3b1a2c62d9d794"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.3.tgz#1b152a9c4f6c9f74bc4bb96233ad0b7983b79744"
 
 colors@~0.6.0:
   version "0.6.2"
@@ -2561,7 +2522,7 @@ colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
-combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
+combined-stream@1.0.6, combined-stream@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
@@ -2635,15 +2596,11 @@ content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
-content-type-parser@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
-
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
-convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
@@ -2675,8 +2632,8 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.4.tgz#f2c8bf181f2a80b92f360121429ce63a2f0aeae0"
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2704,8 +2661,8 @@ cosmiconfig@^4.0.0:
     require-from-string "^2.0.1"
 
 create-ecdh@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.0.tgz#888c723596cdf7612f6498233eebd7a35301737d"
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.1.tgz#44223dfed533193ba5ba54e0df5709b89acf1f82"
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
@@ -2717,17 +2674,18 @@ create-error-class@^3.0.0:
     capture-stack-trace "^1.0.0"
 
 create-hash@^1.1.0, create-hash@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.1.3.tgz#606042ac8b9262750f483caddab0f5819172d8fd"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
   dependencies:
     cipher-base "^1.0.1"
     inherits "^2.0.1"
-    ripemd160 "^2.0.0"
+    md5.js "^1.3.4"
+    ripemd160 "^2.0.1"
     sha.js "^2.4.0"
 
 create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.6.tgz#acb9e221a4e17bdb076e90657c42b93e3726cf06"
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
   dependencies:
     cipher-base "^1.0.3"
     create-hash "^1.1.0"
@@ -2772,12 +2730,6 @@ cross-spawn@^6.0.5:
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-
-cryptiles@2.x.x:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
-  dependencies:
-    boom "2.x.x"
 
 cryptiles@3.x.x:
   version "3.1.2"
@@ -2914,6 +2866,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
+csstype@^2.2.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.4.2.tgz#158e36c69566bf968da63d0ba14eda1c20e8643a"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -2936,17 +2892,25 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-urls@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.0.0.tgz#24802de4e81c298ea8a9388bb0d8e461c774684f"
+  dependencies:
+    abab "^1.0.4"
+    whatwg-mimetype "^2.0.0"
+    whatwg-url "^6.4.0"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.0.1, debug@^3.1.0:
+debug@^3.0.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -2977,9 +2941,9 @@ deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
-deep-extend@~0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+deep-extend@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -3086,8 +3050,8 @@ diff@^3.2.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 diffie-hellman@^5.0.0:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
   dependencies:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
@@ -3116,7 +3080,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.2.0:
+dom-helpers@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -3238,17 +3202,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-to-chromium@^1.2.7:
-  version "1.3.42"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz#95c33bf01d0cc405556aec899fe61fd4d76ea0f9"
-
-electron-to-chromium@^1.3.30:
-  version "1.3.34"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.34.tgz#d93498f40391bb0c16a603d8241b9951404157ed"
-
-electron-to-chromium@^1.3.41:
-  version "1.3.41"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.41.tgz#7e33643e00cd85edfd17e04194f6d00e73737235"
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.42:
+  version "1.3.44"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.44.tgz#ef6b150a60d523082388cadad88085ecd2fd4684"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -3356,19 +3312,9 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.10.0, es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.9.0:
+es-abstract@^1.10.0, es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.6.1, es-abstract@^1.7.0, es-abstract@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
-  dependencies:
-    es-to-primitive "^1.1.1"
-    function-bind "^1.1.1"
-    has "^1.0.1"
-    is-callable "^1.1.3"
-    is-regex "^1.0.4"
-
-es-abstract@^1.6.1, es-abstract@^1.7.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -3481,14 +3427,14 @@ escope@^3.6.0:
     estraverse "^4.1.1"
 
 eslint-plugin-flowtype@^2.39.1:
-  version "2.46.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.46.1.tgz#c4f81d580cd89c82bc3a85a1ccf4ae3a915143a4"
+  version "2.46.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.46.3.tgz#7e84131d87ef18b496b1810448593374860b4e8e"
   dependencies:
     lodash "^4.15.0"
 
 eslint-plugin-jest@^21.12.3:
-  version "21.15.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.15.0.tgz#645a3f560d3e61d99611b215adc80b4f31e6d896"
+  version "21.15.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.15.1.tgz#662a3f0888002878f0f388efd09c190a95c33d82"
 
 eslint-plugin-react@^7.7.0:
   version "7.7.0"
@@ -3577,8 +3523,8 @@ esprima@^4.0.0, esprima@~4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
 
 esquery@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
     estraverse "^4.0.0"
 
@@ -3759,13 +3705,13 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
+extend@^3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
 external-editor@^2.0.4:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
   dependencies:
     chardet "^0.4.0"
     iconv-lite "^0.4.17"
@@ -3803,14 +3749,14 @@ fast-deep-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-glob@^2.0.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.0.tgz#e9d032a69b86bef46fc03d935408f02fb211d9fc"
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.1.tgz#686c2345be88f3741e174add0be6f2e5b6078889"
   dependencies:
     "@mrmlnc/readdir-enhanced" "^2.2.1"
     glob-parent "^3.1.0"
     is-glob "^4.0.0"
     merge2 "^1.2.1"
-    micromatch "^3.1.8"
+    micromatch "^3.1.10"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -4005,8 +3951,8 @@ flow-coverage-report@^0.5.0:
     yargs "8.0.1"
 
 flow-parser@^0.*:
-  version "0.69.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.69.0.tgz#378b5128d6d0b554a8b2f16a4ca3e1ab9649f00e"
+  version "0.71.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.71.0.tgz#da2479b83f9207905b4b17ab0c4e6d17bd505250"
 
 flow-remove-types@^1.2.3:
   version "1.2.3"
@@ -4060,14 +4006,6 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@~2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.12"
-
 form-data@~2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
@@ -4109,6 +4047,12 @@ fs-extra@^5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  dependencies:
+    minipass "^2.2.1"
+
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -4123,21 +4067,13 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
 fsevents@^1.1.1, fsevents@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.3.tgz#08292982e7059f6674c93d8b829c1e8604979ac0"
   dependencies:
-    nan "^2.3.0"
-    node-pre-gyp "^0.6.39"
+    nan "^2.9.2"
+    node-pre-gyp "^0.9.0"
 
-fstream-ignore@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
-  dependencies:
-    fstream "^1.0.0"
-    inherits "2"
-    minimatch "^3.0.0"
-
-fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2, fstream@~1.0.10:
+fstream@~1.0.10:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
   dependencies:
@@ -4232,15 +4168,16 @@ glamor@^2.20.40:
     through "^2.3.8"
 
 glamorous@^4.12.1:
-  version "4.12.1"
-  resolved "https://registry.yarnpkg.com/glamorous/-/glamorous-4.12.1.tgz#bcfa00f3d24c9232da33bc2b415e0d3ca7b10f68"
+  version "4.12.5"
+  resolved "https://registry.yarnpkg.com/glamorous/-/glamorous-4.12.5.tgz#909e0ec2ab3136e4749bf82edd9f33b51745e41f"
   dependencies:
     brcast "^3.0.0"
+    csstype "^2.2.0"
     fast-memoize "^2.2.7"
     html-tag-names "^1.1.1"
     is-function "^1.0.1"
     is-plain-object "^2.0.4"
-    react-html-attributes "^1.3.0"
+    react-html-attributes "^1.4.2"
     svg-tag-names "^1.1.0"
 
 glob-base@^0.3.0:
@@ -4336,13 +4273,9 @@ global@^4.3.2:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^11.0.1:
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.4.0.tgz#b85c793349561c16076a3c13549238a27945f1bc"
-
-globals@^11.1.0:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
+globals@^11.0.1, globals@^11.1.0:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.5.0.tgz#6bc840de6771173b191f13d3a9c94d441ee92642"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -4375,7 +4308,7 @@ globjoin@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
 
-gonzales-pe@^4.2.3:
+gonzales-pe@4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.2.3.tgz#41091703625433285e0aee3aa47829fc1fbeb6f2"
   dependencies:
@@ -4440,20 +4373,9 @@ handlebars@^4.0.3:
   optionalDependencies:
     uglify-js "^2.6"
 
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-
-har-validator@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
-  dependencies:
-    ajv "^4.9.1"
-    har-schema "^1.0.5"
 
 har-validator@~5.0.3:
   version "5.0.3"
@@ -4535,12 +4457,6 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
-hash-base@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-2.0.2.tgz#66ea1d856db4e8a5470cadf6fce23ae5244ef2e1"
-  dependencies:
-    inherits "^2.0.1"
-
 hash-base@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918"
@@ -4554,15 +4470,6 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
-
-hawk@3.1.3, hawk@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
-  dependencies:
-    boom "2.x.x"
-    cryptiles "2.x.x"
-    hoek "2.x.x"
-    sntp "1.x.x"
 
 hawk@~6.0.2:
   version "6.0.2"
@@ -4584,10 +4491,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoek@2.x.x:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hoek@4.x.x:
   version "4.2.1"
@@ -4623,8 +4526,8 @@ html-comment-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
 
 html-element-attributes@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/html-element-attributes/-/html-element-attributes-1.3.0.tgz#f06ebdfce22de979db82020265cac541fb17d4fc"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/html-element-attributes/-/html-element-attributes-1.3.1.tgz#9fa6a2e37e6b61790a303e87ddbbb9746e8c035f"
 
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
@@ -4647,8 +4550,8 @@ html-loader@^0.5.5:
     object-assign "^4.1.1"
 
 html-minifier@^3.2.3, html-minifier@^3.5.8:
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.13.tgz#6bca6d533a7f18a476dc6aeb3d113071ab5c165e"
+  version "3.5.15"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.15.tgz#f869848d4543cbfd84f26d5514a2a87cbf9a05e0"
   dependencies:
     camel-case "3.0.x"
     clean-css "4.1.x"
@@ -4659,8 +4562,8 @@ html-minifier@^3.2.3, html-minifier@^3.5.8:
     uglify-js "3.3.x"
 
 html-tag-names@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/html-tag-names/-/html-tag-names-1.1.2.tgz#f65168964c5a9c82675efda882875dcb2a875c22"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/html-tag-names/-/html-tag-names-1.1.3.tgz#f81f75e59d626cb8a958a19e58f90c1d69707b82"
 
 html-tags@^2.0.0:
   version "2.0.0"
@@ -4716,16 +4619,8 @@ http-errors@~1.6.2:
     statuses ">= 1.4.0 < 2"
 
 http-parser-js@>=0.4.0:
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.11.tgz#5b720849c650903c27e521633d94696ee95f3529"
-
-http-signature@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
-  dependencies:
-    assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
+  version "0.4.12"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.12.tgz#b9cfbf4a2cf26f0fc34b10ca1489a27771e3474f"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -4743,9 +4638,15 @@ hyphenate-style-name@^1.0.1, hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
-iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
+iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
+  dependencies:
+    safer-buffer "^2.1.0"
 
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
@@ -4765,9 +4666,15 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
+ignore-walk@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  dependencies:
+    minimatch "^3.0.4"
+
 ignore@^3.3.3, ignore@^3.3.5:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
 
 immutable@^3.8.1:
   version "3.8.2"
@@ -4882,13 +4789,7 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.0.0, invariant@^2.2.0:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.3.tgz#1a827dfde7dcbd7c323f0ca826be8fa7c5e9d688"
-  dependencies:
-    loose-envify "^1.0.0"
-
-invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -4919,16 +4820,16 @@ is-accessor-descriptor@^1.0.0:
     kind-of "^6.0.0"
 
 is-alphabetical@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.1.tgz#c77079cc91d4efac775be1034bf2d243f95e6f08"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.2.tgz#1fa6e49213cb7885b75d15862fb3f3d96c884f41"
 
 is-alphanumeric@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
 
 is-alphanumerical@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz#dfb4aa4d1085e33bdb61c2dee9c80e9c6c19f53b"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz#1138e9ae5040158dc6ff76b820acd6b7a181fd40"
   dependencies:
     is-alphabetical "^1.0.0"
     is-decimal "^1.0.0"
@@ -4984,8 +4885,8 @@ is-date-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-decimal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.1.tgz#f5fb6a94996ad9e8e3761fbfbd091f1fca8c4e82"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.2.tgz#894662d6a8709d307f3a276ca4339c8fa5dff0ff"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -5082,8 +4983,8 @@ is-glob@^4.0.0:
     is-extglob "^2.1.1"
 
 is-hexadecimal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz#6e084bbc92061fbb0971ec58b6ce6d404e24da69"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
 
 is-installed-globally@^0.1.0:
   version "0.1.0"
@@ -5235,8 +5136,8 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
 is-whitespace-character@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz#9ae0176f3282b65457a1992cdb084f8a5f833e3b"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
 
 is-windows@^0.2.0:
   version "0.2.0"
@@ -5247,8 +5148,8 @@ is-windows@^1.0.1, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 is-word-character@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.1.tgz#5a03fa1ea91ace8a6eb0c7cd770eb86d65c8befb"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.2.tgz#46a5dac3f2a1840898b91e576cd40d493f3ae553"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -5314,7 +5215,7 @@ istanbul-lib-hook@^1.2.0:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.7.5, istanbul-lib-instrument@^1.8.0:
+istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.8.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
   dependencies:
@@ -5681,17 +5582,16 @@ jscodeshift@^0.5.0:
     write-file-atomic "^1.2.0"
 
 jsdom@^11.5.1:
-  version "11.6.2"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.6.2.tgz#25d1ef332d48adf77fc5221fe2619967923f16bb"
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.10.0.tgz#a42cd54e88895dc765f03f15b807a474962ac3b5"
   dependencies:
     abab "^1.0.4"
     acorn "^5.3.0"
     acorn-globals "^4.1.0"
     array-equal "^1.0.0"
-    browser-process-hrtime "^0.1.2"
-    content-type-parser "^1.0.2"
     cssom ">= 0.3.2 < 0.4.0"
     cssstyle ">= 0.2.37 < 0.3.0"
+    data-urls "^1.0.0"
     domexception "^1.0.0"
     escodegen "^1.9.0"
     html-encoding-sniffer "^1.0.2"
@@ -5707,6 +5607,7 @@ jsdom@^11.5.1:
     w3c-hr-time "^1.0.1"
     webidl-conversions "^4.0.2"
     whatwg-encoding "^1.0.3"
+    whatwg-mimetype "^2.1.0"
     whatwg-url "^6.4.0"
     ws "^4.0.0"
     xml-name-validator "^3.0.0"
@@ -5831,8 +5732,8 @@ lcid@^1.0.0:
     invert-kv "^1.0.0"
 
 left-pad@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.2.0.tgz#d30a73c6b8201d8f7d8e7956ba9616087a68e0ee"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
 leven@^2.1.0:
   version "2.1.0"
@@ -5912,8 +5813,8 @@ locate-path@^2.0.0:
     path-exists "^3.0.0"
 
 lodash-es@^4.17.5, lodash-es@^4.2.1:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.5.tgz#9fc6e737b1c4d151d8f9cae2247305d552ce748f"
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
 
 lodash._getnative@^3.0.0:
   version "3.9.1"
@@ -5979,13 +5880,13 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^3.10.1, lodash@^3.3.1:
+lodash@^3.3.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
 lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 log-symbols@^2.0.0:
   version "2.2.0"
@@ -6068,8 +5969,8 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 markdown-escapes@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.1.tgz#1994df2d3af4811de59a6714934c2b2292734518"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
 
 markdown-loader@^2.0.2:
   version "2.0.2"
@@ -6079,8 +5980,8 @@ markdown-loader@^2.0.2:
     marked "^0.3.9"
 
 markdown-table@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.1.tgz#4b3dd3a133d1518b8ef0dbc709bf2a1b4824bc8c"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
 
 marked@^0.3.9:
   version "0.3.19"
@@ -6103,8 +6004,8 @@ math-expression-evaluator@^1.2.14:
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
 
 mathml-tag-names@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.0.1.tgz#8d41268168bf86d1102b98109e28e531e7a34578"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.0.2.tgz#87fbdeb16382b7f17a04a8841fe8bc52b4f4a5e0"
 
 md5.js@^1.3.4:
   version "1.3.4"
@@ -6146,8 +6047,8 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
     readable-stream "^2.0.1"
 
 meow@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-4.0.0.tgz#fd5855dd008db5b92c552082db1c307cba20b29d"
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-4.0.1.tgz#d48598f6f4b1472f35bf6317a95945ace347f975"
   dependencies:
     camelcase-keys "^4.0.0"
     decamelize-keys "^1.0.0"
@@ -6208,7 +6109,7 @@ micromatch@^2.3.11, micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.4, micromatch@^3.1.8:
+micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -6237,7 +6138,7 @@ mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
@@ -6266,8 +6167,8 @@ min-document@^2.19.0:
     dom-walk "^0.1.0"
 
 minimalistic-assert@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
 
 minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
@@ -6279,7 +6180,7 @@ minimatch@3.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -6308,6 +6209,19 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
+minipass@^2.2.1, minipass@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.2.4.tgz#03c824d84551ec38a8d1bb5bc350a5a30a354a40"
+  dependencies:
+    safe-buffer "^5.1.1"
+    yallist "^3.0.0"
+
+minizlib@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
+  dependencies:
+    minipass "^2.2.1"
+
 mississippi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
@@ -6330,19 +6244,15 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
 moment@^2.21.0:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
-
-moo@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.1.tgz#529a2e9bf973f259c9643d237fda84de3a26e8ad"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -6371,7 +6281,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.0:
+nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -6397,22 +6307,29 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 nearley@^2.7.10:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.12.1.tgz#589cc3f883f5f873902b719838abd45af57b2d69"
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.13.0.tgz#6e7b0f4e68bfc3e74c99eaef2eda39e513143439"
   dependencies:
-    moo "^0.4.3"
     nomnom "~1.6.2"
     railroad-diagrams "^1.0.0"
     randexp "0.4.6"
     semver "^5.4.1"
+
+needle@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
 
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
 neo-async@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.0.tgz#76b1c823130cca26acfbaccc8fbaf0a2fa33b18f"
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
 
 nested-object-assign@^1.0.1:
   version "1.0.2"
@@ -6494,21 +6411,20 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@^0.6.39:
-  version "0.6.39"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
+node-pre-gyp@^0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz#f11c07516dd92f87199dbc7e1838eab7cd56c9e0"
   dependencies:
     detect-libc "^1.0.2"
-    hawk "3.1.3"
     mkdirp "^0.5.1"
+    needle "^2.2.0"
     nopt "^4.0.1"
+    npm-packlist "^1.1.6"
     npmlog "^4.0.2"
     rc "^1.1.7"
-    request "2.81.0"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tar "^2.2.1"
-    tar-pack "^3.4.0"
+    tar "^4"
 
 node-version@^1.0.0:
   version "1.1.3"
@@ -6567,6 +6483,17 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
+npm-bundled@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
+
+npm-packlist@^1.1.6:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.10.tgz#1039db9e985727e464df066f4cf0ab6ef85c398a"
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -6600,7 +6527,7 @@ nwmatcher@^1.4.3:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
 
-oauth-sign@~0.8.1, oauth-sign@~0.8.2:
+oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
@@ -6691,7 +6618,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -6828,8 +6755,8 @@ param-case@2.1.x:
     no-case "^2.2.0"
 
 parse-asn1@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.0.tgz#37c4f9b7ed3ab65c74817b5f2480937fbf97c712"
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.1.tgz#f6bf293818332bd0dab54efb16087724745e6ca8"
   dependencies:
     asn1.js "^4.0.0"
     browserify-aes "^1.0.0"
@@ -6842,8 +6769,8 @@ parse-domain@^2.0.0:
   resolved "https://registry.yarnpkg.com/parse-domain/-/parse-domain-2.0.0.tgz#e9f42f697c30f7c2051dc5c55ff4d8a80da7943c"
 
 parse-entities@^1.0.2, parse-entities@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.1.tgz#8112d88471319f27abae4d64964b122fe4e1b890"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.2.tgz#9eaf719b29dc3bd62246b4332009072e01527777"
   dependencies:
     character-entities "^1.0.0"
     character-entities-legacy "^1.0.0"
@@ -6973,18 +6900,14 @@ path@^0.12.7:
     util "^0.10.3"
 
 pbkdf2@^3.0.3:
-  version "3.0.14"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.14.tgz#a35e13c64799b06ce15320f459c230e68e73bade"
+  version "3.0.16"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.16.tgz#7404208ec6b01b62d85bf83853a8064f8d9c2a5c"
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-performance-now@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -7088,8 +7011,8 @@ postcss-filter-plugins@^2.0.0:
     uniqid "^4.0.0"
 
 postcss-flexbugs-fixes@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.3.0.tgz#e00849b536063749da50a0d410ba5d9ee65e27b8"
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.3.1.tgz#0783cc7212850ef707f97f8bc8b6fb624e00c75d"
   dependencies:
     postcss "^6.0.1"
 
@@ -7134,8 +7057,8 @@ postcss-load-plugins@^2.3.0:
     object-assign "^4.1.0"
 
 postcss-loader@^2.1.2, postcss-loader@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-2.1.3.tgz#eb210da734e475a244f76ccd61f9860f5bb3ee09"
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-2.1.4.tgz#f44a6390e03c84108b2b2063182d1a1011b2ce76"
   dependencies:
     loader-utils "^1.1.0"
     postcss "^6.0.0"
@@ -7304,11 +7227,11 @@ postcss-safe-parser@^3.0.1:
     postcss "^6.0.6"
 
 postcss-sass@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/postcss-sass/-/postcss-sass-0.3.0.tgz#dc2582ee0e61541aa88bafdc5a8aebb53deaae75"
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-sass/-/postcss-sass-0.3.1.tgz#f345c175d35cc15726e1f4c035cedb703dd1ba18"
   dependencies:
-    gonzales-pe "^4.2.3"
-    postcss "^6.0.16"
+    gonzales-pe "4.2.3"
+    postcss "6.0.22"
 
 postcss-scss@^1.0.2:
   version "1.0.5"
@@ -7368,6 +7291,14 @@ postcss-zindex@^2.0.1:
     postcss "^5.0.4"
     uniqs "^2.0.0"
 
+postcss@6.0.22, postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.16, postcss@^6.0.17, postcss@^6.0.21, postcss@^6.0.22, postcss@^6.0.6, postcss@^6.0.8:
+  version "6.0.22"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
 postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.2, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.2.16:
   version "5.2.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
@@ -7376,14 +7307,6 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     js-base64 "^2.1.9"
     source-map "^0.5.6"
     supports-color "^3.2.3"
-
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.16, postcss@^6.0.17, postcss@^6.0.20, postcss@^6.0.21, postcss@^6.0.6, postcss@^6.0.8:
-  version "6.0.21"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.21.tgz#8265662694eddf9e9a5960db6da33c39e4cd069d"
-  dependencies:
-    chalk "^2.3.2"
-    source-map "^0.6.1"
-    supports-color "^5.3.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -7411,7 +7334,7 @@ pretty-format@^22.4.3:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-private@^0.1.6, private@^0.1.7, private@~0.1.5:
+private@^0.1.6, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -7457,7 +7380,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -7492,8 +7415,8 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 public-encrypt@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.0.tgz#39f699f3a46560dd5ebacbca693caf7c65c18cc6"
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.2.tgz#46eb9107206bf73489f8b85b69d91334c6610994"
   dependencies:
     bn.js "^4.1.0"
     browserify-rsa "^4.0.0"
@@ -7540,10 +7463,6 @@ qs@6.5.1, qs@^6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
@@ -7563,9 +7482,9 @@ querystringify@0.0.x:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-0.0.4.tgz#0cf7f84f9463ff0ae51c4c4b142d95be37724d9c"
 
-querystringify@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
+querystringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
 
 quick-lru@^1.0.0:
   version "1.1.0"
@@ -7631,10 +7550,10 @@ raw-body@2.3.2:
     unpipe "1.0.0"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.6.tgz#eb18989c6d4f4f162c399f79ddd29f3835568092"
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.7.tgz#8a10ca30d588d00464360372b890d06dacd02297"
   dependencies:
-    deep-extend "~0.4.0"
+    deep-extend "^0.5.1"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -7648,8 +7567,8 @@ react-addons-create-fragment@^15.5.3:
     object-assign "^4.1.0"
 
 react-color@^2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.14.0.tgz#5828a11c034aa0939befbd888a066ee37d8c3cc2"
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.14.1.tgz#db8ad4f45d81e74896fc2e1c99508927c6d084e0"
   dependencies:
     lodash "^4.0.1"
     material-colors "^1.2.1"
@@ -7710,18 +7629,9 @@ react-dom@15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
-react-dom@^16.0.0:
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.1.tgz#6a3c90a4fb62f915bdbcf6204422d93a7d4ca573"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react-dom@^16.2.0:
-  version "16.3.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.0.tgz#b318e52184188ecb5c3e81117420cca40618643e"
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -7741,9 +7651,9 @@ react-fuzzy@^0.5.2:
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
 
-react-html-attributes@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/react-html-attributes/-/react-html-attributes-1.4.1.tgz#97b5ec710da68833598c8be6f89ac436216840a5"
+react-html-attributes@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/react-html-attributes/-/react-html-attributes-1.4.2.tgz#0d2ccf134fc79b2d3543837dc1591d32b7b903f9"
   dependencies:
     html-element-attributes "^1.0.0"
 
@@ -7758,18 +7668,27 @@ react-icons@^2.2.7:
     react-icon-base "2.1.0"
 
 react-inspector@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.2.tgz#c04f5248fa92ab6c23e37960e725fb7f48c34d05"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.3.0.tgz#fc9c1d38ab687fc0d190dcaf133ae40158968fc8"
   dependencies:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
+react-is@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
+
+react-lifecycles-compat@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.2.tgz#7279047275bd727a912e25f734c0559527e84eff"
+
 react-modal@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.3.2.tgz#b13da9490653a7c76bc0e9600323eb1079c620e7"
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.4.4.tgz#e9dde25e9e85a59c76831f2a2b468712a546aded"
   dependencies:
     exenv "^1.2.0"
     prop-types "^15.5.10"
+    react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
 react-onclickoutside@^6.5.0:
@@ -7811,12 +7730,13 @@ react-style-proptype@^3.0.0:
     prop-types "^15.5.4"
 
 react-test-renderer@^16.0.0-0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+    react-is "^16.3.2"
 
 react-textarea-autosize@^5.2.1:
   version "5.2.1"
@@ -7824,15 +7744,13 @@ react-textarea-autosize@^5.2.1:
   dependencies:
     prop-types "^15.6.0"
 
-react-transition-group@^1.1.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
+react-transition-group@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.1.tgz#31d611b33e143a5e0f2d94c348e026a0f3b474b6"
   dependencies:
-    chain-function "^1.0.0"
-    dom-helpers "^3.2.0"
+    dom-helpers "^3.3.1"
     loose-envify "^1.3.1"
-    prop-types "^15.5.6"
-    warning "^3.0.0"
+    prop-types "^15.6.1"
 
 react-treebeard@^2.1.0:
   version "2.1.0"
@@ -7854,18 +7772,9 @@ react@15.5.4:
     object-assign "^4.1.0"
     prop-types "^15.5.7"
 
-react@^16.0.0:
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.3.1.tgz#4a2da433d471251c69b6033ada30e2ed1202cfd8"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react@^16.2.0:
-  version "16.3.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.3.0.tgz#fc5a01c68f91e9b38e92cf83f7b795ebdca8ddff"
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -7923,16 +7832,16 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 readable-stream@1.0:
@@ -8226,33 +8135,6 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@2.81.0:
-  version "2.81.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~4.2.1"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    performance-now "^0.2.0"
-    qs "~6.4.0"
-    safe-buffer "^5.0.1"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
-
 request@^2.83.0:
   version "2.85.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
@@ -8289,8 +8171,8 @@ require-from-string@^1.1.0:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
 
 require-from-string@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
 
 require-main-filename@^1.0.1:
   version "1.0.1"
@@ -8303,7 +8185,7 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requires-port@1.0.x, requires-port@~1.0.0:
+requires-port@1.0.x, requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
@@ -8348,8 +8230,8 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resolve@^1.1.6, resolve@^1.3.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.6.0.tgz#0fbd21278b27b4004481c395349e7aba60a9ff5c"
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
   dependencies:
     path-parse "^1.0.5"
 
@@ -8377,7 +8259,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -8388,10 +8270,10 @@ rimraf@~2.2.6:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
   dependencies:
-    hash-base "^2.0.0"
+    hash-base "^3.0.0"
     inherits "^2.0.1"
 
 rst-selector-parser@^2.2.3:
@@ -8433,15 +8315,23 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
   dependencies:
     ret "~0.1.10"
+
+safer-buffer@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 sane@^2.0.0:
   version "2.5.0"
@@ -8471,7 +8361,7 @@ schema-utils@^0.3.0:
   dependencies:
     ajv "^5.0.0"
 
-schema-utils@^0.4.0, schema-utils@^0.4.2, schema-utils@^0.4.5:
+schema-utils@^0.4.0, schema-utils@^0.4.4, schema-utils@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.5.tgz#21836f0608aac17b78f9e3e24daff14a5ca13a3e"
   dependencies:
@@ -8507,8 +8397,8 @@ send@0.16.2:
     statuses "~1.4.0"
 
 serialize-javascript@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.4.0.tgz#7c958514db6ac2443a8abc062dc9f7886a7f6005"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
 
 serve-favicon@^2.4.5:
   version "2.5.0"
@@ -8656,12 +8546,6 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sntp@1.x.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
-  dependencies:
-    hoek "2.x.x"
-
 sntp@2.x.x:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
@@ -8706,9 +8590,10 @@ source-map-support@^0.4.15:
     source-map "^0.5.6"
 
 source-map-support@^0.5.0:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.4.tgz#54456efa89caa9270af7cd624cc2f123e51fbae8"
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.5.tgz#0d4af9e00493e855402e8ec36ebed2d266fceb90"
   dependencies:
+    buffer-from "^1.0.0"
     source-map "^0.6.0"
 
 source-map-url@^0.4.0:
@@ -8790,8 +8675,8 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
 state-toggle@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.0.tgz#d20f9a616bb4f0c3b98b91922d25b640aa2bc425"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.1.tgz#c3cb0974f40a6a0f8e905b96789eb41afa1cde3a"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -8882,7 +8767,7 @@ string.prototype.padstart@^3.0.0:
     es-abstract "^1.4.3"
     function-bind "^1.0.2"
 
-string_decoder@^1.0.0:
+string_decoder@^1.0.0, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
@@ -8892,22 +8777,16 @@ string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
-  dependencies:
-    safe-buffer "~5.1.0"
-
 stringify-entities@^1.0.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.1.tgz#b150ec2d72ac4c1b5f324b51fb6b28c9cdff058c"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.2.tgz#a98417e5471fd227b3e45d3db1861c11caf668f7"
   dependencies:
     character-entities-html4 "^1.0.0"
     character-entities-legacy "^1.0.0"
     is-alphanumerical "^1.0.0"
     is-hexadecimal "^1.0.0"
 
-stringstream@~0.0.4, stringstream@~0.0.5:
+stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
@@ -9036,9 +8915,9 @@ supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+supports-color@^5.3.0, supports-color@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
     has-flag "^3.0.0"
 
@@ -9110,26 +8989,17 @@ tapable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
 
-tar-pack@^3.4.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
+tar@^4:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.2.tgz#60685211ba46b38847b1ae7ee1a24d744a2cd462"
   dependencies:
-    debug "^2.2.0"
-    fstream "^1.0.10"
-    fstream-ignore "^1.0.5"
-    once "^1.3.3"
-    readable-stream "^2.1.4"
-    rimraf "^2.5.1"
-    tar "^2.2.1"
-    uid-number "^0.0.6"
-
-tar@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
-  dependencies:
-    block-stream "*"
-    fstream "^1.0.2"
-    inherits "2"
+    chownr "^1.0.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.2.4"
+    minizlib "^1.1.0"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
 
 temp@0.8.3, temp@^0.8.1:
   version "0.8.3"
@@ -9151,7 +9021,7 @@ terminal-table@0.0.12:
     colors "^1.0.3"
     eastasianwidth "^0.1.0"
 
-test-exclude@^4.1.1:
+test-exclude@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
   dependencies:
@@ -9189,8 +9059,8 @@ timed-out@^4.0.0:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
 timers-browserify@^2.0.4:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.6.tgz#241e76927d9ca05f4d959819022f5b3664b64bae"
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
   dependencies:
     setimmediate "^1.0.4"
 
@@ -9243,16 +9113,16 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     safe-regex "^1.1.0"
 
 toposort@^1.0.0:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.6.tgz#c31748e55d210effc00fdcdc7d6e68d7d7bb9cec"
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
 
-tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
     punycode "^1.4.1"
 
-tr46@^1.0.0:
+tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
   dependencies:
@@ -9271,16 +9141,16 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 trim-trailing-lines@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz#7aefbb7808df9d669f6da2e438cac8c46ada7684"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz#e0ec0810fd3c3f1730516b45f49083caaf2774d9"
 
 trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
 trough@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.1.tgz#a9fd8b0394b0ae8fff82e0633a0a36ccad5b5f86"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.2.tgz#7f1663ec55c480139e2de5e486c6aef6cc24a535"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -9325,8 +9195,8 @@ uglify-es@^3.3.4:
     source-map "~0.6.1"
 
 uglify-js@3.3.x:
-  version "3.3.18"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.18.tgz#e16df66d71638df3c9bc61cce827e46f24bdac02"
+  version "3.3.23"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.23.tgz#48ea43e638364d18be292a6fdc2b5b7c35f239ab"
   dependencies:
     commander "~2.15.0"
     source-map "~0.6.1"
@@ -9353,8 +9223,8 @@ uglifyjs-webpack-plugin@^0.4.6:
     webpack-sources "^1.0.1"
 
 uglifyjs-webpack-plugin@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.4.tgz#5eec941b2e9b8538be0a20fc6eda25b14c7c1043"
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz#2ef8387c8f1a903ec5e44fa36f9f3cbdcea67641"
   dependencies:
     cacache "^10.0.4"
     find-cache-dir "^1.0.0"
@@ -9364,10 +9234,6 @@ uglifyjs-webpack-plugin@^1.2.4:
     uglify-es "^3.3.4"
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
-
-uid-number@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
 underscore.string@~2.4.0:
   version "2.4.0"
@@ -9386,8 +9252,8 @@ underscore@~1.7.0:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
 
 unherit@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.0.tgz#6b9aaedfbf73df1756ad9e316dd981885840cd7d"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.1.tgz#132748da3e88eab767e08fabfbb89c5e9d28628c"
   dependencies:
     inherits "^2.0.1"
     xtend "^4.0.1"
@@ -9452,24 +9318,24 @@ unist-util-find-all-after@^1.0.1:
     unist-util-is "^2.0.0"
 
 unist-util-is@^2.0.0, unist-util-is@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.1.tgz#0c312629e3f960c66e931e812d3d80e77010947b"
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
 
 unist-util-modify-children@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.1.tgz#66d7e6a449e6f67220b976ab3cb8b5ebac39e51d"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz#c7f1b91712554ee59c47a05b551ed3e052a4e2d1"
   dependencies:
     array-iterate "^1.0.0"
 
 unist-util-remove-position@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz#5a85c1555fc1ba0c101b86707d15e50fa4c871bb"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz#86b5dad104d0bbfbeb1db5f5c92f3570575c12cb"
   dependencies:
     unist-util-visit "^1.1.0"
 
 unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz#3ccbdc53679eed6ecf3777dd7f5e3229c1b6aa3c"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
 
 unist-util-visit@^1.1.0:
   version "1.3.0"
@@ -9497,8 +9363,8 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
 unzipper@^0.8.11:
-  version "0.8.12"
-  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.8.12.tgz#178de4e263d96a2550fb6f4804d26c06edb9c8bd"
+  version "0.8.13"
+  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.8.13.tgz#ea889ca10cdda4dcf604e632f19fc5f81871beae"
   dependencies:
     big-integer "^1.6.17"
     binary "~0.3.0"
@@ -9511,12 +9377,12 @@ unzipper@^0.8.11:
     setimmediate "~1.0.4"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.5.tgz#02cab9ecebe95bbec6d5fc2566325725ab6d1a73"
 
 update-notifier@^2.3.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.4.0.tgz#f9b4c700fbfd4ec12c811587258777d563d8c866"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
   dependencies:
     boxen "^1.2.1"
     chalk "^2.0.1"
@@ -9565,11 +9431,11 @@ url-parse@1.0.x:
     requires-port "1.0.x"
 
 url-parse@^1.1.8:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.3.0.tgz#04a06c420d22beb9804f7ada2d57ad13160a4258"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.0.tgz#6bfdaad60098c7fe06f623e42b22de62de0d3d75"
   dependencies:
-    querystringify "~1.0.0"
-    requires-port "~1.0.0"
+    querystringify "^2.0.0"
+    requires-port "^1.0.0"
 
 url-to-options@^1.0.1:
   version "1.0.1"
@@ -9617,7 +9483,7 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^3.0.0, uuid@^3.1.0, uuid@^3.2.1:
+uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
@@ -9637,17 +9503,17 @@ velocity-animate@^1.4.0:
   resolved "https://registry.yarnpkg.com/velocity-animate/-/velocity-animate-1.5.1.tgz#606837047bab8fbfb59a636d1d82ecc3f7bd71a6"
 
 velocity-react@^1.3.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/velocity-react/-/velocity-react-1.3.3.tgz#d6d47276cfc8be2a75623879b20140ac58c1b82b"
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/velocity-react/-/velocity-react-1.4.1.tgz#1d0b41859cdf2521c08a8b57f44e93ed2d54b5fc"
   dependencies:
-    lodash "^3.10.1"
+    lodash "^4.17.5"
     prop-types "^15.5.8"
-    react-transition-group "^1.1.2"
+    react-transition-group "^2.0.0"
     velocity-animate "^1.4.0"
 
 vendors@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.1.tgz#37ad73c8ee417fb3d580e785312307d274847f22"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.2.tgz#7fcb5eef9f5623b156bcea89ec37d63676f21801"
 
 verror@1.10.0:
   version "1.10.0"
@@ -9712,14 +9578,14 @@ watch@~0.18.0:
     minimist "^1.2.0"
 
 watchpack@^1.4.0, watchpack@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.5.0.tgz#231e783af830a22f8966f65c4c4bacc814072eed"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
   dependencies:
     chokidar "^2.0.2"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
-webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
+webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
@@ -9733,9 +9599,9 @@ webpack-dev-middleware@^1.12.2:
     range-parser "^1.0.3"
     time-stamp "^2.0.0"
 
-webpack-hot-middleware@^2.21.2:
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.21.2.tgz#2e2aa65563b8b32546b67e53b5a9667dcd80f327"
+webpack-hot-middleware@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.22.1.tgz#2ff865bfebc8e9937bd1619f0f48d6ab601bfea0"
   dependencies:
     ansi-html "0.0.7"
     html-entities "^1.2.0"
@@ -9777,8 +9643,8 @@ webpack@^3.11.0:
     yargs "^8.0.2"
 
 webpack@^4.0.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.4.1.tgz#b0105789890c28bfce9f392623ef5850254328a4"
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.6.0.tgz#363eafa733710eb0ed28c512b2b9b9f5fb01e69b"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^3.0.0"
@@ -9794,7 +9660,7 @@ webpack@^4.0.1:
     mkdirp "~0.5.0"
     neo-async "^2.5.0"
     node-libs-browser "^2.0.0"
-    schema-utils "^0.4.2"
+    schema-utils "^0.4.4"
     tapable "^1.0.0"
     uglifyjs-webpack-plugin "^1.2.4"
     watchpack "^1.5.0"
@@ -9821,13 +9687,17 @@ whatwg-fetch@>=0.10.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
+whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
+
 whatwg-url@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.1.tgz#fdb94b440fd4ad836202c16e9737d511f012fd67"
   dependencies:
     lodash.sortby "^4.7.0"
-    tr46 "^1.0.0"
-    webidl-conversions "^4.0.1"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 whet.extend@~0.9.9:
   version "0.9.9"
@@ -9956,6 +9826,10 @@ y18n@^4.0.0:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
 yargs-parser@^2.4.1:
   version "2.4.1"


### PR DESCRIPTION
- 「あなた」，「勝者」，「敗者」の3つのグループに分け，この順番で表示する
- 自分の結果は「勝者」もしくは「敗者」でも表示する．なので，自分の結果は2回表示される．
- 旧実装では勝敗を色で示していたが上記のグループ分けにより不要になったので消去
- スペース節約のため，勝敗の項目を削除
- 「勝者」，「敗者」の中の表示の順番は「生存」，「死亡」の順
- 「生存」，「死亡」の中の表示の順番は辞書順．辞書順はブラウザの実装に依存している．
- 「閉じる」ボタンを追加した．押すと`CLOSE_RESULT`のActionがDispatchされる．その後の処理は書いてない